### PR TITLE
feat: :sparkles: update task_types array to include "build" for PR Conventional Commit Validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -11,4 +11,4 @@ jobs:
       - name: PR Conventional Commit Validation
         uses: ytanikin/PRConventionalCommits@1.1.0
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert", "build"]'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the GitHub Actions workflow to include "build" as a recognized commit type for validation.
  
- **Chores**
	- Improved commit quality and adherence to conventional commit standards through updated workflow configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->