### PR TITLE
chore: bump PR title validation version

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/PRConventionalCommits@1.1.0
+        uses: ytanikin/PRConventionalCommits@1.3.0
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert", "build"]'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/pr-validation.yml` file. The change updates the version of the `ytanikin/PRConventionalCommits` action to ensure compatibility with the latest features and bug fixes.

* [`.github/workflows/pr-validation.yml`](diffhunk://#diff-04af3c9c96028eebf4fa93d5c67e1fa08255fb7a3682f912ccd5bea1dff5ccd4L12-R12): Updated `ytanikin/PRConventionalCommits` action from version `1.1.0` to `1.3.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the pull request validation workflow to a newer version for improved performance. 
	- Maintained the list of accepted task types for conventional commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->