### PR TITLE
feat: migrate local email testing to Mailpit

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,7 @@ on:
       - "yarn.lock"
       - "go.mod"
       - "go.sum"
+      - "mise.toml"
   pull_request:
     branches: [main]
     paths:
@@ -28,6 +29,7 @@ on:
       - "yarn.lock"
       - "go.mod"
       - "go.sum"
+      - "mise.toml"
 jobs:
   backend-quality-gates:
     runs-on: ubuntu-latest
@@ -132,11 +134,15 @@ jobs:
           name: wga
           path: ./wga_tmp
       - name: Download Mailpit
-        run: wget https://github.com/axllent/mailpit/releases/download/v1.14.4/mailpit-linux-amd64.tar.gz
+        run: wget -q -O mailpit-linux-amd64.tar.gz https://github.com/axllent/mailpit/releases/download/v1.30.4/mailpit-linux-amd64.tar.gz
+      - name: Verify Mailpit archive
+        run: echo "e9c104154c22b83ac4c7d19f9d665a5c933585a3caafcd790805d732fa8d03fb  mailpit-linux-amd64.tar.gz" | sha256sum --check --status
       - name: Extract Mailpit
         run: tar -xvf mailpit-linux-amd64.tar.gz
       - name: Run Mailpit
-        run: ./mailpit -v > mailpit.log &
+        run: ./mailpit --smtp 127.0.0.1:1025 --listen 127.0.0.1:8025 --log-file mailpit.log &
+      - name: Wait for Mailpit
+        run: for i in {1..30}; do curl --fail --silent --show-error http://127.0.0.1:8025/readyz && exit 0; sleep 1; done; exit 1
       - name: Install Bun dependencies
         run: bun install
       - name: Get installed Playwright version
@@ -183,7 +189,7 @@ jobs:
       - name: Run Playwright tests
         run: bunx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         env:
-          MAILPIT_URL: ${{ vars.MAILPIT_URL }}
+          MAILPIT_URL: http://127.0.0.1:8025
           WGA_PROTOCOL: ${{ vars.WGA_PROTOCOL }}
           WGA_HOSTNAME: ${{ vars.WGA_HOSTNAME }}
       - uses: actions/upload-artifact@v4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,7 +58,6 @@
     "Lexend",
     "linecap",
     "linejoin",
-    "mailhog",
     "Mailpit",
     "metafile",
     "migratecmd",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,16 @@
 - Use Go 1.25.2 (`go.mod`/`mise.toml`), Bun, and Templ. `devenv shell` is the documented development environment; `mise` pins the same toolchain and exposes equivalent tasks as `mise run <task>`.
 - Create `.env` from `.env.example` (`mise run app:init-env`). `godotenv.Load()` reads the default `.env` from the process working directory: `code:run` uses the repository root, while `app:run` changes into `dist/`.
 - `wga_data` is likewise relative to the process working directory. `app:run` uses `dist/wga_data`; clear the data directory used by the launcher rather than assuming root `wga_data` is the active one.
-- `devenv up` starts JS/CSS/Templ watchers, MailHog, and MinIO, but not the application server. Start it separately with `code:run`, or use `app:build` followed by `app:run`.
+- `devenv up` starts JS/CSS/Templ watchers, Mailpit, and MinIO, but not the application server. Start it separately with `code:run`, or use `app:build` followed by `app:run`.
 - `app:build` runs `bun install`, `bun run build`, `templ generate`, `go mod tidy`, then builds `dist/wga`. `seed:images` is registered only when `WGA_ENV=development`.
 
 ## Verification and workflow
 
 - Backend CI order is `go mod tidy`, `go vet ./...`, then `go test ./... -cover`. For a focused check, use commands such as `go test ./internal/handlers/dual -run '^TestResolvePaneTarget$'`.
 - `mise run check` runs the local Go pre-commit checks (`go vet` and `golangci-lint`), not the test suite. `.pre-commit-config.yaml` is generated; do not edit it.
-- Playwright has no active `webServer` setting. Before `bunx playwright test` (or one spec such as `bunx playwright test playwright-tests/artwork-search.spec.ts`), start the app and set `WGA_PROTOCOL`, `WGA_HOSTNAME`, and a reachable `MAILPIT_URL`; the postcard spec requires the mail UI.
+- Playwright has no active `webServer` setting. Before `bunx playwright test` (or one spec such as `bunx playwright test playwright-tests/artwork-search.spec.ts`), start the app and set `WGA_PROTOCOL`, `WGA_HOSTNAME`, and a reachable `MAILPIT_URL`; the postcard spec queries the Mailpit API.
 - The full Go suite includes a mail-send test that skips only when no `sendmail` executable is available.
 - `biome.json` configures JS/TS tabs, double quotes, and import organisation. The Playwright CI workflow also runs Prettier on changed JS and Markdown files.
 - PR titles must use one of the Conventional Commit types enforced by `.github/workflows/pr-validation.yml`: `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore`, `revert`, or `build`.
 - Non-`main` deployment runs only when the head commit message contains `deploy-dev`; release tags matching `v*.*.*` invoke GoReleaser.
-- When changing repository documentation, read `docs/documentation-maintenance.md`; it identifies the authoritative config and CI sources, including the MailHog versus `MAILPIT_URL` distinction.
+- When changing repository documentation, read `docs/documentation-maintenance.md`; it identifies the authoritative config and CI sources, including the Mailpit service and `MAILPIT_URL` endpoint.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ mise run app:init-env
 mise run dev
 ```
 
-`mise run dev` starts the asset and template watchers, MailHog (SMTP on port 1025 and web UI on port 8025), and MinIO; run the application separately with `mise run code:run`.
+`mise run dev` starts the asset and template watchers, Mailpit (SMTP on port 1025 and HTTP API on port 8025), and MinIO; run the application separately with `mise run code:run`.
 
 The main project tasks are:
 

--- a/DESIGN_DOCUMENT.md
+++ b/DESIGN_DOCUMENT.md
@@ -133,7 +133,7 @@ The application is organized into functional packages under `internal/handlers/`
 
 - **Prerequisites:** Mise installs the configured Go, Bun, and Templ versions from `mise.toml`.
 - **Environment Variables:** A `.env` file is required in the process working directory. `mise run app:init-env` creates one in the repository root.
-- **Services:** `mise run dev` starts local MinIO and MailHog alongside the asset and template watchers.
+- **Services:** `mise run dev` starts local MinIO and Mailpit alongside the asset and template watchers.
 - **Running:**
   1.  `mise run app:init-env`
   2.  `mise run dev`

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ MAILPIT_URL=
 | `WGA_SENDER_ADDRESS`   | The sending email address                                                                              |
 | `WGA_SENDER_NAME`      | The name of the email sender                                                                           |
 | `WGA_RECAPTCHA_SECRET` | The reCAPTCHA secret used to verify postcard submissions                                               |
-| `MAILPIT_URL`          | The local mail UI endpoint that Playwright checks during end-to-end tests                              |
+| `MAILPIT_URL`          | The local Mailpit HTTP endpoint that Playwright queries during end-to-end tests                        |
 
 ### Running the application
 
@@ -120,7 +120,7 @@ Start the local asset watchers and services with Mise:
 mise run dev
 ```
 
-`mise run dev` starts the frontend and template watchers, MailHog (SMTP on port 1025 and web UI on port 8025), and MinIO. Playwright reads `MAILPIT_URL` as the browser endpoint for inspecting captured messages. In another terminal, start the application with `mise run code:run`, or run `mise run app:build` followed by `mise run app:run`.
+`mise run dev` starts the frontend and template watchers, Mailpit (SMTP on port 1025 and HTTP API on port 8025), and MinIO. Playwright reads `MAILPIT_URL` to query captured messages. In another terminal, start the application with `mise run code:run`, or run `mise run app:build` followed by `mise run app:run`.
 
 If you only need asset watchers, use the package scripts directly:
 
@@ -148,7 +148,7 @@ mise install
 mise run app:init-env
 ```
 
-`mise.toml` defines the pinned tools, local environment defaults, build tasks, watchers, and local MailHog and MinIO services.
+`mise.toml` defines the pinned tools, local environment defaults, build tasks, watchers, and local Mailpit and MinIO services.
 
 ## License
 

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -19,7 +19,7 @@ Check these files before editing docs that describe structure, commands, testing
 
 - Confirm the current path model still starts at `cmd/wga/main.go`, `internal/*`, `resources/*`, and `playwright-tests/*`.
 - Confirm built-binary instructions still use `dist/wga` rather than a root-level binary path.
-- Confirm local mail wording still distinguishes the `mailhog` service from the `MAILPIT_URL` browser endpoint used by Playwright.
+- Confirm local mail wording identifies the `mailpit` service and the `MAILPIT_URL` endpoint used by Playwright's Mailpit API checks.
 - Confirm the command being documented exists exactly where the docs claim it does, especially `mise install`, `mise run dev`, `mise run app:build`, `mise run app:run`, `mise run code:run`, `go test ./... -cover`, and `bunx playwright test`.
 - Confirm environment-variable docs still match `.env.example`, including `WGA_RECAPTCHA_SECRET` and `MAILPIT_URL`.
 - Confirm whether the docs change also requires updating secondary or generated guidance, such as `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `.planning/codebase/*`, or historical summary docs.

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ go = "1.26.5"
 "go:github.com/air-verse/air" = "latest"
 "http:mc" = { version = "RELEASE.2025-08-13T08-35-41Z", url = "https://dl.min.io/client/mc/release/linux-amd64/archive/mc.{{ version }}", bin = "mc", checksum = "sha256:01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891" }
 "http:minio" = { version = "RELEASE.2025-09-07T16-13-09Z", url = "https://dl.min.io/server/minio/release/linux-amd64/archive/minio.{{ version }}", bin = "minio", checksum = "sha256:7c5bd8512c6e966455b1d198209358b2d191c77a83ab377c4073281065fb855f" }
-"http:MailHog" = { version = "1.0.1", url = "https://github.com/mailhog/MailHog/releases/download/v{{ version }}/MailHog_linux_amd64", bin = "MailHog" }
+"http:mailpit" = { version = "1.30.4", url = "https://github.com/axllent/mailpit/releases/download/v{{ version }}/mailpit-linux-amd64.tar.gz", bin = "mailpit", checksum = "sha256:e9c104154c22b83ac4c7d19f9d665a5c933585a3caafcd790805d732fa8d03fb" }
 "github:golangci/golangci-lint" = "latest"
 "aqua:superfly/flyctl" = "latest"
 
@@ -21,12 +21,12 @@ WGA_ADMIN_PASSWORD = "VerySecurePassword" # admin password
 WGA_PROTOCOL = "http" # http or https
 WGA_HOSTNAME = "localhost:8090" # hostname (and port)
 WGA_SMTP_HOST = "127.0.0.1" # smtp server
-WGA_SMTP_PORT = "1025" # MailHog SMTP port
+WGA_SMTP_PORT = "1025" # Mailpit SMTP port
 WGA_SMTP_USERNAME = "" # smtp username
 WGA_SMTP_PASSWORD = "" # smtp password
 WGA_SENDER_ADDRESS = "do-not-reply@wga.hu" # sender email address
 WGA_SENDER_NAME = "WGA" # sender name
-MAILPIT_URL = "http://127.0.0.1:8025" # MailHog web UI endpoint
+MAILPIT_URL = "http://127.0.0.1:8025" # Mailpit HTTP endpoint
 
 [tasks."app:versions"]
 description = "Print versions of the core development tools."
@@ -101,9 +101,9 @@ run = "templ generate --watch"
 description = "Watch and build CSS assets."
 run = "bun run build:watch:css"
 
-[tasks."service:mailhog"]
-description = "Run the local MailHog SMTP server and web UI."
-run = "MailHog -smtp-bind-addr 127.0.0.1:1025 -api-bind-addr 127.0.0.1:8025 -ui-bind-addr 127.0.0.1:8025"
+[tasks."service:mailpit"]
+description = "Run the local Mailpit SMTP server and HTTP API."
+run = "mailpit --smtp 127.0.0.1:1025 --listen 127.0.0.1:8025"
 
 [tasks."service:minio"]
 description = "Run MinIO and initialise the local wga bucket."
@@ -131,6 +131,6 @@ wait "$minio_pid"
 '''
 
 [tasks.dev]
-description = "Start asset watchers, template generation, MailHog, and MinIO."
+description = "Start asset watchers, template generation, Mailpit, and MinIO."
 alias = "up"
-run = "mise run --jobs 5 watch:js ::: watch:templ ::: watch:css ::: service:mailhog ::: service:minio"
+run = "mise run --jobs 5 watch:js ::: watch:templ ::: watch:css ::: service:mailpit ::: service:minio"

--- a/playwright-tests/postcard.spec.ts
+++ b/playwright-tests/postcard.spec.ts
@@ -1,67 +1,124 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-test("send postcard", async ({ page }) => {
-  await page.goto("/artists/koedijck-isaack-3ed9e200b9e8252");
-  await page.getByRole("link", { name: "Send postcard" }).click();
+type MailpitAddress = {
+	Address: string;
+};
 
-  await expect(page.locator("#d")).toBeVisible();
+type MailpitMessageSummary = {
+	ID: string;
+	Subject: string;
+};
 
-  await expect(page.locator("#d")).toHaveText(/Write a postcard/);
+type MailpitSearchResponse = {
+	messages: MailpitMessageSummary[];
+};
 
-  await page.locator("[name='sender_name']").fill("Playwright Tester");
-  await page
-    .locator("[name='sender_email']")
-    .fill("playwright.tester@local.host"); // this is the postcard sender's email
-  await page
-    .locator("[name='recipients[]']")
-    .fill("playwright.tester@local.host"); // this is the postcard recipient's email
-  await page.locator("trix-editor").fill("I am testing your site.");
+type MailpitMessage = {
+	From: MailpitAddress;
+	To: MailpitAddress[];
+	Subject: string;
+	HTML: string;
+};
 
-  await page.getByRole("button", { name: "Send postcard" }).click();
+test("send postcard", async ({ page, request }) => {
+	test.setTimeout(150000);
 
-  await expect(page.locator(".toast")).toHaveText(
-    /Thank you! Your postcard has been queued for sending!/,
-  );
+	const mailpitUrl = process.env.MAILPIT_URL;
+	if (!mailpitUrl) {
+		throw new Error("MAILPIT_URL environment variable is not set.");
+	}
 
-  const mailpitUrl = process.env.MAILPIT_URL;
-  if (!mailpitUrl) {
-    throw new Error("MAILPIT_URL environment variable is not set.");
-  }
-  await page.goto(mailpitUrl);
+	const recipient = "playwright.tester@local.host";
+	const subject = "You got a postcard from Playwright Tester!";
+	const searchUrl = `${mailpitUrl}/api/v1/search?${new URLSearchParams({
+		query: `to:${recipient}`,
+	})}`;
+	const existingMessagesResponse = await request.get(searchUrl);
+	expect(existingMessagesResponse.ok()).toBeTruthy();
+	const existingMessages =
+		(await existingMessagesResponse.json()) as MailpitSearchResponse;
+	const existingMessageIDs = existingMessages.messages
+		.filter((message) => message.Subject === subject)
+		.map((message) => message.ID);
 
-  try {
-    await page
-      .getByRole("link", { name: "WGA playwright.tester@local." })
-      .nth(0)
-      .click({
-        timeout: 90 * 60 * 1000,
-      });
-  } catch (e) {
-    console.error("Error: ", e);
-    page.reload();
-    await page
-      .getByRole("link", { name: "WGA playwright.tester@local." })
-      .nth(0)
-      .click({
-        timeout: 90 * 60 * 1000,
-      });
-  }
+	if (existingMessageIDs.length > 0) {
+		const deleteResponse = await request.delete(
+			`${mailpitUrl}/api/v1/messages`,
+			{ data: { ids: existingMessageIDs } },
+		);
+		expect(deleteResponse.ok()).toBeTruthy();
+	}
 
-  const postcardLink = await page
-    .frameLocator("#preview-html")
-    .getByRole("link", { name: "Pickup my Postcard!" })
-    .getAttribute("href", { timeout: 90000 });
+	await page.goto("/artists/koedijck-isaack-3ed9e200b9e8252");
+	await page.getByRole("link", { name: "Send postcard" }).click();
 
-  await page.getByRole("button", { name: /Delete/ }).click();
+	await expect(page.locator("#d")).toBeVisible();
 
-  if (!postcardLink) {
-    throw new Error("Postcard link not found");
-  }
+	await expect(page.locator("#d")).toHaveText(/Write a postcard/);
 
-  console.log("Postcard link: ", postcardLink);
+	await page.locator("[name='sender_name']").fill("Playwright Tester");
+	await page
+		.locator("[name='sender_email']")
+		.fill("playwright.tester@local.host"); // this is the postcard sender's email
+	await page.locator("[name='recipients[]']").fill(recipient); // this is the postcard recipient's email
+	await page.locator("trix-editor").fill("I am testing your site.");
 
-  await page.goto(postcardLink);
-  await expect(page.locator("#mc-area")).toContainText([
-    "I am testing your site",
-  ]);
+	await page.getByRole("button", { name: "Send postcard" }).click();
+
+	await expect(page.locator(".toast")).toHaveText(
+		/Thank you! Your postcard has been queued for sending!/,
+	);
+
+	let messageID = "";
+	try {
+		await expect
+			.poll(
+				async () => {
+					const response = await request.get(searchUrl);
+					if (!response.ok()) {
+						return "";
+					}
+
+					const messages = (await response.json()) as MailpitSearchResponse;
+					messageID =
+						messages.messages.find((message) => message.Subject === subject)
+							?.ID ?? "";
+					return messageID;
+				},
+				{ intervals: [1000, 2000, 5000], timeout: 120000 },
+			)
+			.toBeTruthy();
+
+		const messageResponse = await request.get(
+			`${mailpitUrl}/api/v1/message/${messageID}`,
+		);
+		expect(messageResponse.ok()).toBeTruthy();
+		const message = (await messageResponse.json()) as MailpitMessage;
+		expect(message.From.Address).toBe("do-not-reply@wga.hu");
+		expect(message.To.map((address) => address.Address)).toContain(recipient);
+		expect(message.Subject).toBe(subject);
+		expect(message.HTML).toContain(
+			"Playwright Tester has left postcard for you to pick up",
+		);
+
+		const postcardLink = message.HTML.match(
+			/<a\b[^>]*\bhref=["']([^"']+)["'][^>]*>\s*Pickup my Postcard!\s*<\/a>/i,
+		)?.[1];
+		if (!postcardLink) {
+			throw new Error("Postcard link not found");
+		}
+
+		await page.goto(postcardLink);
+		await expect(page.locator("#mc-area")).toContainText([
+			"I am testing your site",
+		]);
+	} finally {
+		if (messageID) {
+			const deleteResponse = await request.delete(
+				`${mailpitUrl}/api/v1/messages`,
+				{ data: { ids: [messageID] } },
+			);
+			expect(deleteResponse.ok()).toBeTruthy();
+		}
+	}
 });


### PR DESCRIPTION
## Summary
- replace local MailHog tooling with checksum-pinned Mailpit v1.30.4
- standardise Mailpit CI startup, checksum verification, readiness, and local endpoint use
- query captured postcard emails through Mailpit API instead of its web UI
- update contributor and project documentation

## Validation
- `go test ./... -cover` — passed (66 packages)
- `bunx biome check playwright-tests/postcard.spec.ts` — passed
- Playwright test discovery — passed
- Mailpit readiness and API send/search/get/delete probe — passed
- Focused postcard E2E — currently blocked by the existing postcard dialog remaining hidden before email delivery

Unrelated pre-existing worktree changes were not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local development and automated tests now use Mailpit for email delivery and message verification.
  * Added reliable email readiness checks and message cleanup during end-to-end testing.

* **Documentation**
  * Updated setup guides and development documentation with Mailpit endpoints, ports, and usage.
  * Clarified the `MAILPIT_URL` configuration used by Playwright tests.

* **Bug Fixes**
  * Improved email test reliability by verifying messages through Mailpit’s API instead of its web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->