### PR TITLE
fix: restore Playwright browser journeys

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -165,7 +165,7 @@ jobs:
         run: chmod +x ./wga
         working-directory: ./wga_tmp
       - name: Run the application
-        run: ./wga serve --dev > wga.log &
+        run: ./wga serve > wga.log &
         working-directory: ./wga_tmp
         env:
           WGA_PROTOCOL: http

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -246,14 +246,3 @@ jobs:
           name: html-report--attempt-${{ github.run_attempt }}
           path: playwright-report
           retention-days: 14
-      - name: Upload HTML report to Azure
-        shell: bash
-        run: |
-          REPORT_DIR='run-${{ github.run_id }}-${{ github.run_attempt }}'
-          azcopy cp --recursive "./playwright-report/*" "https://wga.blob.core.windows.net/\$web/$REPORT_DIR"
-          echo "::notice title=HTML report url::https://wga.z6.web.core.windows.net/$REPORT_DIR/index.html"
-        env:
-          AZCOPY_AUTO_LOGIN_TYPE: SPN
-          AZCOPY_SPA_APPLICATION_ID: "${{ secrets.AZCOPY_SPA_APPLICATION_ID }}"
-          AZCOPY_SPA_CLIENT_SECRET: "${{ secrets.AZCOPY_SPA_CLIENT_SECRET }}"
-          AZCOPY_TENANT_ID: "${{ secrets.AZCOPY_TENANT_ID }}"

--- a/internal/assets/templ/layouts/layout.templ
+++ b/internal/assets/templ/layouts/layout.templ
@@ -71,7 +71,7 @@ templ LayoutBase(bodyClasses string, HtmxTargetArea string) {
 				hx-swap="innerHTML"
 			>Feedback</a>
 			<div class="toast" id="toast-container"></div>
-			<script src="/assets/js/app.js"></script>
+			<script type="module" src="/assets/js/app.js"></script>
 			<script defer src="/assets/js/vendor/cookieconsent.js" crossorigin="anonymous"></script>
 			<script defer src="/assets/js/vendor/cookieconsent-init.js" crossorigin="anonymous"></script>
 		</body>

--- a/internal/handlers/postcards/save.go
+++ b/internal/handlers/postcards/save.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/blackfyre/wga/internal/constants"
 	"github.com/blackfyre/wga/internal/errs"
@@ -77,7 +78,7 @@ func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonda
 	record.Set("status", "queued")
 	record.Set("sender_name", postData.SenderName)
 	record.Set("sender_email", postData.SenderEmail)
-	record.Set("recipients", postData.Recipients)
+	record.Set("recipients", strings.Join(postData.Recipients, ","))
 	record.Set("message", p.Sanitize(postData.Message))
 	record.Set("image_id", postData.ImageId)
 	record.Set("notify_sender", postData.NotificationRequired)

--- a/playwright-tests/feedback.spec.ts
+++ b/playwright-tests/feedback.spec.ts
@@ -21,7 +21,7 @@ test("check feedback", async ({ page }) => {
   await page.getByRole("button", { name: "Send feedback" }).click();
 
   // expect notification popup: Thank you! Your feedback is valuable to us!
-  await expect(page.locator(".toast")).toHaveText(
+  await expect(page.locator(".toast")).toContainText(
     "Thank you! Your feedback is valuable to us!",
   );
 });

--- a/playwright-tests/guestbook.spec.ts
+++ b/playwright-tests/guestbook.spec.ts
@@ -10,7 +10,10 @@ const entry = {
 
 test("test", async ({ page }) => {
   await page.goto("/");
-  await page.getByRole("link", { name: "Guestbook" }).click();
+  await page
+    .getByRole("navigation", { name: "main navigation" })
+    .getByRole("link", { name: "Guestbook", exact: true })
+    .click();
   await page.getByRole("link", { name: "Add Entry" }).click();
   await page.getByPlaceholder("Your name", { exact: true }).fill(entry.name);
   await page.getByPlaceholder("Your name", { exact: true }).press("Tab");

--- a/playwright-tests/postcard.spec.ts
+++ b/playwright-tests/postcard.spec.ts
@@ -62,6 +62,14 @@ test("send postcard", async ({ page, request }) => {
 		.fill("playwright.tester@local.host"); // this is the postcard sender's email
 	await page.locator("[name='recipients[]']").fill(recipient); // this is the postcard recipient's email
 	await page.locator("trix-editor").fill("I am testing your site.");
+	// The CI handler skips remote verification but still requires a token.
+	await page.locator("#postcard_create").evaluate((form) => {
+		const token = document.createElement("input");
+		token.name = "g-recaptcha-response";
+		token.type = "hidden";
+		token.value = "playwright-test-token";
+		form.append(token);
+	});
 
 	await page.getByRole("button", { name: "Send postcard" }).click();
 


### PR DESCRIPTION
Fixes #162

## Summary

- Serve the downloaded Playwright artefact in normal mode so it uses embedded frontend assets.
- Load the code-split app.js bundle as an ES module.
- Scope Guestbook navigation to the main navigation landmark and assert the feedback toast message without coupling to its intentional heading.
- Persist postcard recipients as the comma-separated text expected by the postcard mailer, and provide the deterministic test CAPTCHA response required when CI skips remote verification.
- Retain the 14-day GitHub Actions HTML-report artifact and remove the obsolete Azure upload step and AzCopy credential dependency.

## Verification

- go vet ./...
- go test ./... -cover
- go tool templ generate
- bun run build
- Parsed the Playwright workflow YAML after removing the Azure step.
- Built a normal-mode binary and verified its served app.js and style.css SHA-256 values match the build outputs.
- bunx playwright test --project=chromium --reporter=line: 17 passed.

## Scope

The production CAPTCHA-widget integration is a follow-up and is not changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed postcard recipient persistence so multiple recipients are saved as intended.
  * Improved app JavaScript loading by switching to ES module script loading for more consistent behavior.

* **Tests**
  * Updated Playwright feedback assertions to use partial text matching.
  * Improved Playwright guestbook navigation by scoping link selection to the main navigation.
  * Updated Playwright postcard submission to inject a stable reCAPTCHA token during the send flow.

* **Chores**
  * Adjusted Playwright test runtime startup and simplified report handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->