### PR TITLE
feat: add progressive Dual Mode path loading

### DIFF
--- a/docs/features/dual-mode-legacy-parity.md
+++ b/docs/features/dual-mode-legacy-parity.md
@@ -70,10 +70,11 @@ The legacy page recommends a 1024 × 768 display. The modern view activates at 7
 
 #### Item: Direct selection and pane operations
 
+- [x] Add progressive canonical-path forms for either pane. **Verified by:** Go URL-state coverage and JavaScript-enabled and JavaScript-disabled Playwright journeys.
 - [ ] Add searchable artist and artwork selection for either pane. **Done when:** a visitor can select either content type without manually constructing a path.
-- [ ] Add copy, reverse, and clear controls. **Done when:** each operation updates both rendered panes and the shareable URL without a full document navigation.
-- [ ] Add an explicit Standard view action. **Done when:** it has a clear destination and is operable by keyboard and screen reader.
-- [ ] Add focused Go and Playwright coverage for every pane operation and URL-state transition. **Done when:** success and empty-pane paths are covered.
+- [x] Add copy, reverse, and clear controls. **Verified by:** the operation-link Go and Playwright coverage, including URL state and fallback navigation.
+- [x] Add an explicit Standard view action. **Verified by:** the operation-link Playwright journey.
+- [x] Add focused Go and Playwright coverage for every pane operation and URL-state transition. **Verified by:** success, empty-pane, HTMX, and JavaScript-disabled journeys.
 
 #### Item: Catalogue entry points and search
 

--- a/internal/assets/templ/dto/dto.go
+++ b/internal/assets/templ/dto/dto.go
@@ -82,3 +82,15 @@ type DualViewDto struct {
 	ClearLeftUrl              string
 	ClearRightUrl             string
 }
+
+type DualPaneLoadFormDto struct {
+	Path          string
+	OtherPath     string
+	LeftRenderTo  string
+	RightRenderTo string
+}
+
+type DualPaneLoadFormsDto struct {
+	Left  DualPaneLoadFormDto
+	Right DualPaneLoadFormDto
+}

--- a/internal/assets/templ/pages/dual.templ
+++ b/internal/assets/templ/pages/dual.templ
@@ -5,7 +5,7 @@ import (
 	"github.com/blackfyre/wga/internal/assets/templ/layouts"
 )
 
-templ DualPage(c dto.DualViewDto) {
+templ DualPage(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
 	@layouts.LayoutBase("", "#dual-area") {
 		<div class="p-4 md:hidden">
 			<div role="alert" class="alert alert-warning">
@@ -32,7 +32,7 @@ templ DualPage(c dto.DualViewDto) {
 			<div id="right" class="w-full overflow-y-auto py-10 pl-5 pr-10">
 				@templ.Raw(c.Right)
 			</div>
-			@DualNav(c)
+			@DualNav(c, forms)
 		</main>
 	}
 }
@@ -74,7 +74,7 @@ templ DualPaneDefault(side string) {
 	</div>
 }
 
-templ DualNav(c dto.DualViewDto) {
+templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
 	<div id="dual-nav" class="col-span-2 row-start-2 border-t border-base-300 bg-base-100/95 px-6 py-4 backdrop-blur">
 		<div class="flex flex-wrap items-center justify-between gap-4">
 			<nav class="flex items-center gap-2" aria-label="Left pane controls">
@@ -112,6 +112,10 @@ templ DualNav(c dto.DualViewDto) {
 			<a class="btn btn-sm" href={ c.ClearRightUrl } hx-get={ c.ClearRightUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">Clear right</a>
 			<a class="btn btn-sm" href="/">Standard view</a>
 		</nav>
+		<section class="mt-3 grid gap-3 md:grid-cols-2" aria-label="Load pane paths">
+			@DualPanePathForm("left", forms.Left)
+			@DualPanePathForm("right", forms.Right)
+		</section>
 	</div>
 	<dialog id="artist_lookup" class="modal">
 		<div class="modal-box">
@@ -123,4 +127,39 @@ templ DualNav(c dto.DualViewDto) {
 		</form>
 	</dialog>
 	@templ.JSONScript("artistList", c.ArtistNameList)
+}
+
+templ DualPanePathForm(side string, form dto.DualPaneLoadFormDto) {
+	<form
+		action="/dual-mode"
+		aria-label={ "Load " + side + " pane" }
+		class="flex flex-col gap-2 rounded-box border border-base-300 p-3"
+		hx-get="/dual-mode"
+		hx-push-url="true"
+		hx-select="#dual-area"
+		hx-swap="outerHTML"
+		hx-target="#dual-area"
+		method="GET"
+	>
+		<label class="form-control w-full" for={ side + "-pane-path" }>
+			<span class="label-text text-sm">Load { side } pane path</span>
+			<input
+				class="input input-bordered w-full"
+				id={ side + "-pane-path" }
+				name={ side }
+				placeholder="/artists/... or /artworks/..."
+				spellcheck="false"
+				type="text"
+				value={ form.Path }
+			/>
+		</label>
+		if side == "left" {
+			<input type="hidden" name="right" value={ form.OtherPath }/>
+		} else {
+			<input type="hidden" name="left" value={ form.OtherPath }/>
+		}
+		<input type="hidden" name="left_render_to" value={ form.LeftRenderTo }/>
+		<input type="hidden" name="right_render_to" value={ form.RightRenderTo }/>
+		<button type="submit" class="btn btn-sm">Load { side }</button>
+	</form>
 }

--- a/internal/handlers/dual/main.go
+++ b/internal/handlers/dual/main.go
@@ -77,7 +77,7 @@ func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error 
 
 	var buff bytes.Buffer
 
-	err = pages.DualPage(contentDto).Render(ctx, &buff)
+	err = pages.DualPage(contentDto, buildDualPaneLoadForms(leftPane, rightPane)).Render(ctx, &buff)
 
 	if err != nil {
 		app.Logger().Error("Error rendering dual mode page", "error", err.Error())
@@ -128,6 +128,31 @@ func buildDualModeActionURL(leftPane renderPaneDto, rightPane renderPaneDto, act
 	}
 
 	return buildDualModeURL(leftPath, rightPath, leftPane.RenderTo, rightPane.RenderTo)
+}
+
+func buildDualPaneLoadForms(leftPane renderPaneDto, rightPane renderPaneDto) dto.DualPaneLoadFormsDto {
+	return dto.DualPaneLoadFormsDto{
+		Left: dto.DualPaneLoadFormDto{
+			Path:          panePathInputValue(leftPane.RelPath),
+			OtherPath:     rightPane.RelPath,
+			LeftRenderTo:  leftPane.RenderTo,
+			RightRenderTo: rightPane.RenderTo,
+		},
+		Right: dto.DualPaneLoadFormDto{
+			Path:          panePathInputValue(rightPane.RelPath),
+			OtherPath:     leftPane.RelPath,
+			LeftRenderTo:  leftPane.RenderTo,
+			RightRenderTo: rightPane.RenderTo,
+		},
+	}
+}
+
+func panePathInputValue(relPath string) string {
+	if relPath == "default" {
+		return ""
+	}
+
+	return relPath
 }
 
 func buildDualModePaneURL(side string, currentRelPath string, destinationRelPath string, queryValues map[string][]string) string {

--- a/internal/handlers/dual/main_test.go
+++ b/internal/handlers/dual/main_test.go
@@ -210,6 +210,42 @@ func TestBuildDualModeActionURL(t *testing.T) {
 	}
 }
 
+func TestBuildDualPaneLoadForms(t *testing.T) {
+	left := renderPaneDto{RelPath: "/artists/left-123", RenderTo: "right"}
+	right := renderPaneDto{RelPath: "/artworks/right-456", RenderTo: "left"}
+
+	got := buildDualPaneLoadForms(left, right)
+	want := dto.DualPaneLoadFormsDto{
+		Left: dto.DualPaneLoadFormDto{
+			Path:          left.RelPath,
+			OtherPath:     right.RelPath,
+			LeftRenderTo:  "right",
+			RightRenderTo: "left",
+		},
+		Right: dto.DualPaneLoadFormDto{
+			Path:          right.RelPath,
+			OtherPath:     left.RelPath,
+			LeftRenderTo:  "right",
+			RightRenderTo: "left",
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}
+
+func TestBuildDualPaneLoadFormsBlankDefaultPath(t *testing.T) {
+	left := renderPaneDto{RelPath: "default", RenderTo: "right"}
+	right := renderPaneDto{RelPath: "/artworks/right-456", RenderTo: "left"}
+
+	forms := buildDualPaneLoadForms(left, right)
+
+	if forms.Left.Path != "" || forms.Right.OtherPath != "default" {
+		t.Fatalf("expected blank default input and preserved path, got %#v", forms)
+	}
+}
+
 func TestBuildDualModePaneURL(t *testing.T) {
 	artistPath := "/artists/aagaard-carl-frederik-f2540d7a3fe99f9"
 	artworkPath := "/artists/aagaard-carl-frederik-f2540d7a3fe99f9/deer-beside-a-lake-a6aab5e26c30056"

--- a/playwright-tests/dual-mode.spec.ts
+++ b/playwright-tests/dual-mode.spec.ts
@@ -1,19 +1,32 @@
 import { expect, test } from "@playwright/test";
 
 const aachenPath = "/artists/aachen-hans-von-139ac2dff50d65c";
+const aachenArtworkPath =
+	"/artists/aachen-hans-von-139ac2dff50d65c/a-couple-in-a-tavern-4035847eedfacc4";
 const koedijckPath = "/artists/koedijck-isaack-3ed9e200b9e8252";
 
-const dualModeURL = (left: string, right: string) =>
-	`/dual-mode?left=${encodeURIComponent(left)}&right=${encodeURIComponent(right)}&left_render_to=right&right_render_to=left`;
+const dualModeURL = (
+	left: string,
+	right: string,
+	leftRenderTo = "right",
+	rightRenderTo = "left",
+) =>
+	`/dual-mode?left=${encodeURIComponent(left)}&right=${encodeURIComponent(right)}&left_render_to=${leftRenderTo}&right_render_to=${rightRenderTo}`;
 
-const expectDualModeState = async (page, left: string, right: string) => {
+const expectDualModeState = async (
+	page,
+	left: string,
+	right: string,
+	leftRenderTo = "right",
+	rightRenderTo = "left",
+) => {
 	await expect(page).toHaveURL(
 		(url) =>
 			url.pathname === "/dual-mode" &&
 			url.searchParams.get("left") === left &&
 			url.searchParams.get("right") === right &&
-			url.searchParams.get("left_render_to") === "right" &&
-			url.searchParams.get("right_render_to") === "left",
+			url.searchParams.get("left_render_to") === leftRenderTo &&
+			url.searchParams.get("right_render_to") === rightRenderTo,
 	);
 };
 
@@ -159,6 +172,62 @@ test("updates pane state through enhanced operation links", async ({
 	await expect(page).toHaveURL(/\/$/);
 });
 
+test("loads pane paths through enhanced forms", async ({ page }) => {
+	const leftForm = page.getByRole("form", { name: "Load left pane" });
+	const rightForm = page.getByRole("form", { name: "Load right pane" });
+
+	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await expect(leftForm.getByLabel("Load left pane path")).toHaveValue(
+		aachenPath,
+	);
+	const leftResponse = page.waitForResponse(
+		(response) =>
+			response.url().includes("/dual-mode") &&
+			response.request().headers()["hx-request"] === "true",
+	);
+	await leftForm.getByLabel("Load left pane path").fill(koedijckPath);
+	await leftForm
+		.getByRole("button", { name: "Load left", exact: true })
+		.click();
+	await leftResponse;
+	await expectDualModeState(page, koedijckPath, koedijckPath);
+	await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
+
+	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+	await rightForm.getByLabel("Load right pane path").fill(aachenPath);
+	await rightForm
+		.getByRole("button", { name: "Load right", exact: true })
+		.click();
+	await expectDualModeState(page, aachenPath, aachenPath, "left", "right");
+	await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+
+	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+	await leftForm.getByLabel("Load left pane path").fill(aachenArtworkPath);
+	await leftForm
+		.getByRole("button", { name: "Load left", exact: true })
+		.click();
+	await expectDualModeState(
+		page,
+		aachenArtworkPath,
+		koedijckPath,
+		"left",
+		"right",
+	);
+	await expect(page.locator("#left h1")).toContainText("A Couple in a Tavern");
+
+	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await leftForm
+		.getByLabel("Load left pane path")
+		.fill("/pages/privacy-policy");
+	await leftForm
+		.getByRole("button", { name: "Load left", exact: true })
+		.click();
+	await expectDualModeState(page, "default", koedijckPath);
+	await expect(page.locator("#left")).toContainText(
+		"Choose content for comparison",
+	);
+});
+
 test.describe("Dual Mode operations without JavaScript", () => {
 	test.use({ javaScriptEnabled: false });
 
@@ -172,5 +241,33 @@ test.describe("Dual Mode operations without JavaScript", () => {
 		await expectDualModeState(page, koedijckPath, aachenPath);
 		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
 		await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	});
+
+	test("loads a right pane path through a standard GET form", async ({
+		page,
+	}) => {
+		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		const rightForm = page.getByRole("form", { name: "Load right pane" });
+		await rightForm.getByLabel("Load right pane path").fill(aachenPath);
+		await rightForm
+			.getByRole("button", { name: "Load right", exact: true })
+			.click();
+
+		await expectDualModeState(page, aachenPath, aachenPath);
+		await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	});
+
+	test("loads a left pane path through a standard GET form", async ({
+		page,
+	}) => {
+		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		const leftForm = page.getByRole("form", { name: "Load left pane" });
+		await leftForm.getByLabel("Load left pane path").fill(koedijckPath);
+		await leftForm
+			.getByRole("button", { name: "Load left", exact: true })
+			.click();
+
+		await expectDualModeState(page, koedijckPath, koedijckPath);
+		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
 	});
 });


### PR DESCRIPTION
## Summary

- add labelled, server-rendered GET forms for loading canonical paths into either Dual Mode pane
- preserve the other pane and both per-pane link-target settings through form submission
- progressively enhance form submission with HTMX while retaining native navigation without JavaScript
- extend parity tracking and browser coverage for artists, artwork paths, invalid paths, same-pane targets, and both browser paths

Closes #167
Part of #164

## Validation

- `templ generate`
- `go vet ./...`
- `go test ./... -cover`
- `bunx biome check playwright-tests/dual-mode.spec.ts`
- `bunx prettier --check docs/features/dual-mode-legacy-parity.md`
- `mise exec -- env WGA_PROTOCOL=http WGA_HOSTNAME=127.0.0.1:18092 bunx playwright test playwright-tests/dual-mode.spec.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate path-loading forms for the left and right panes in Dual Mode.
  * Supports selecting render targets, including artwork views.
  * Standard GET-based pane loading now works alongside enhanced interactions.
* **Bug Fixes**
  * Improved handling of default or missing pane paths.
* **Tests**
  * Expanded coverage for pane loading, render-target selection, URL updates, and JavaScript-disabled usage.
* **Documentation**
  * Updated the Dual Mode parity checklist to reflect completed pane operations and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->