### PR TITLE
feat: progressively enhance Dual Mode link targets

### DIFF
--- a/docs/features/dual-mode-legacy-parity.md
+++ b/docs/features/dual-mode-legacy-parity.md
@@ -71,6 +71,7 @@ The legacy page recommends a 1024 × 768 display. The modern view activates at 7
 #### Item: Direct selection and pane operations
 
 - [x] Add progressive canonical-path forms for either pane. **Verified by:** Go URL-state coverage and JavaScript-enabled and JavaScript-disabled Playwright journeys.
+- [x] Add progressive link-target controls for either pane. **Verified by:** Go URL-state coverage and JavaScript-enabled and JavaScript-disabled Playwright journeys.
 - [ ] Add searchable artist and artwork selection for either pane. **Done when:** a visitor can select either content type without manually constructing a path.
 - [x] Add copy, reverse, and clear controls. **Verified by:** the operation-link Go and Playwright coverage, including URL state and fallback navigation.
 - [x] Add an explicit Standard view action. **Verified by:** the operation-link Playwright journey.

--- a/internal/assets/templ/dto/dto.go
+++ b/internal/assets/templ/dto/dto.go
@@ -94,3 +94,10 @@ type DualPaneLoadFormsDto struct {
 	Left  DualPaneLoadFormDto
 	Right DualPaneLoadFormDto
 }
+
+type DualPaneTargetUrlsDto struct {
+	LeftSamePaneUrl   string
+	LeftOtherPaneUrl  string
+	RightSamePaneUrl  string
+	RightOtherPaneUrl string
+}

--- a/internal/assets/templ/pages/dual.templ
+++ b/internal/assets/templ/pages/dual.templ
@@ -5,7 +5,7 @@ import (
 	"github.com/blackfyre/wga/internal/assets/templ/layouts"
 )
 
-templ DualPage(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
+templ DualPage(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto, targets dto.DualPaneTargetUrlsDto) {
 	@layouts.LayoutBase("", "#dual-area") {
 		<div class="p-4 md:hidden">
 			<div role="alert" class="alert alert-warning">
@@ -32,7 +32,7 @@ templ DualPage(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
 			<div id="right" class="w-full overflow-y-auto py-10 pl-5 pr-10">
 				@templ.Raw(c.Right)
 			</div>
-			@DualNav(c, forms)
+			@DualNav(c, forms, targets)
 		</main>
 	}
 }
@@ -74,35 +74,17 @@ templ DualPaneDefault(side string) {
 	</div>
 }
 
-templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
+templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto, targets dto.DualPaneTargetUrlsDto) {
 	<div id="dual-nav" class="col-span-2 row-start-2 border-t border-base-300 bg-base-100/95 px-6 py-4 backdrop-blur">
 		<div class="flex flex-wrap items-center justify-between gap-4">
-			<nav class="flex items-center gap-2" aria-label="Left pane controls">
+			<div class="flex items-center gap-2">
 				<button type="button" class="btn btn-sm" onclick="window.wga.dual.openLookup('left')">Choose left</button>
-				<label class="label cursor-pointer gap-2">
-					<span class="label-text text-sm">Open left links in the other pane</span>
-					<input
-						id="left-open-in-other-pane"
-						type="checkbox"
-						class="toggle toggle-sm"
-						checked?={ c.LeftLinksOpenInOtherPane }
-						onchange="window.wga.dual.setPaneTarget('left', this.checked)"
-					/>
-				</label>
-			</nav>
-			<nav class="flex items-center gap-2" aria-label="Right pane controls">
+				@DualPaneTargetControls("left", c.LeftLinksOpenInOtherPane, targets.LeftSamePaneUrl, targets.LeftOtherPaneUrl)
+			</div>
+			<div class="flex items-center gap-2">
 				<button type="button" class="btn btn-sm" onclick="window.wga.dual.openLookup('right')">Choose right</button>
-				<label class="label cursor-pointer gap-2">
-					<span class="label-text text-sm">Open right links in the other pane</span>
-					<input
-						id="right-open-in-other-pane"
-						type="checkbox"
-						class="toggle toggle-sm"
-						checked?={ c.RightLinksOpenInOtherPane }
-						onchange="window.wga.dual.setPaneTarget('right', this.checked)"
-					/>
-				</label>
-			</nav>
+				@DualPaneTargetControls("right", c.RightLinksOpenInOtherPane, targets.RightSamePaneUrl, targets.RightOtherPaneUrl)
+			</div>
 		</div>
 		<nav class="mt-3 flex flex-wrap items-center gap-2" aria-label="Pane operations">
 			<a class="btn btn-sm" href={ c.CopyLeftToRightUrl } hx-get={ c.CopyLeftToRightUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">Copy left to right</a>
@@ -127,6 +109,19 @@ templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto) {
 		</form>
 	</dialog>
 	@templ.JSONScript("artistList", c.ArtistNameList)
+}
+
+templ DualPaneTargetControls(side string, otherPaneActive bool, samePaneUrl string, otherPaneUrl string) {
+	<nav class="flex flex-wrap items-center gap-1" aria-label={ "Open " + side + " links in" }>
+		<span class="text-sm">Open { side } links in</span>
+		if otherPaneActive {
+			<a class="btn btn-sm" href={ samePaneUrl } hx-get={ samePaneUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">This pane</a>
+			<a class="btn btn-primary btn-sm" aria-current="true" href={ otherPaneUrl } hx-get={ otherPaneUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">Other pane</a>
+		} else {
+			<a class="btn btn-primary btn-sm" aria-current="true" href={ samePaneUrl } hx-get={ samePaneUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">This pane</a>
+			<a class="btn btn-sm" href={ otherPaneUrl } hx-get={ otherPaneUrl } hx-target="#dual-area" hx-select="#dual-area" hx-swap="outerHTML">Other pane</a>
+		}
+	</nav>
 }
 
 templ DualPanePathForm(side string, form dto.DualPaneLoadFormDto) {

--- a/internal/handlers/dual/main.go
+++ b/internal/handlers/dual/main.go
@@ -77,7 +77,11 @@ func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error 
 
 	var buff bytes.Buffer
 
-	err = pages.DualPage(contentDto, buildDualPaneLoadForms(leftPane, rightPane)).Render(ctx, &buff)
+	err = pages.DualPage(
+		contentDto,
+		buildDualPaneLoadForms(leftPane, rightPane),
+		buildDualPaneTargetURLs(leftPane, rightPane),
+	).Render(ctx, &buff)
 
 	if err != nil {
 		app.Logger().Error("Error rendering dual mode page", "error", err.Error())
@@ -144,6 +148,15 @@ func buildDualPaneLoadForms(leftPane renderPaneDto, rightPane renderPaneDto) dto
 			LeftRenderTo:  leftPane.RenderTo,
 			RightRenderTo: rightPane.RenderTo,
 		},
+	}
+}
+
+func buildDualPaneTargetURLs(leftPane renderPaneDto, rightPane renderPaneDto) dto.DualPaneTargetUrlsDto {
+	return dto.DualPaneTargetUrlsDto{
+		LeftSamePaneUrl:   buildDualModeURL(leftPane.RelPath, rightPane.RelPath, "left", rightPane.RenderTo),
+		LeftOtherPaneUrl:  buildDualModeURL(leftPane.RelPath, rightPane.RelPath, "right", rightPane.RenderTo),
+		RightSamePaneUrl:  buildDualModeURL(leftPane.RelPath, rightPane.RelPath, leftPane.RenderTo, "right"),
+		RightOtherPaneUrl: buildDualModeURL(leftPane.RelPath, rightPane.RelPath, leftPane.RenderTo, "left"),
 	}
 }
 

--- a/internal/handlers/dual/main_test.go
+++ b/internal/handlers/dual/main_test.go
@@ -246,6 +246,65 @@ func TestBuildDualPaneLoadFormsBlankDefaultPath(t *testing.T) {
 	}
 }
 
+func TestBuildDualPaneTargetURLs(t *testing.T) {
+	left := renderPaneDto{RelPath: "/artists/left-123", RenderTo: "right"}
+	right := renderPaneDto{RelPath: "/artworks/right-456", RenderTo: "left"}
+	targets := buildDualPaneTargetURLs(left, right)
+
+	tests := []struct {
+		name string
+		url  string
+		want map[string]string
+	}{
+		{
+			name: "left same pane",
+			url:  targets.LeftSamePaneUrl,
+			want: map[string]string{
+				"left":            left.RelPath,
+				"right":           right.RelPath,
+				"left_render_to":  "left",
+				"right_render_to": "left",
+			},
+		},
+		{
+			name: "left other pane",
+			url:  targets.LeftOtherPaneUrl,
+			want: map[string]string{
+				"left":            left.RelPath,
+				"right":           right.RelPath,
+				"left_render_to":  "right",
+				"right_render_to": "left",
+			},
+		},
+		{
+			name: "right same pane",
+			url:  targets.RightSamePaneUrl,
+			want: map[string]string{
+				"left":            left.RelPath,
+				"right":           right.RelPath,
+				"left_render_to":  "right",
+				"right_render_to": "right",
+			},
+		},
+		{
+			name: "right other pane",
+			url:  targets.RightOtherPaneUrl,
+			want: map[string]string{
+				"left":            left.RelPath,
+				"right":           right.RelPath,
+				"left_render_to":  "right",
+				"right_render_to": "left",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertDualModeQuery(t, parseDualModeURL(t, test.url), test.want)
+		})
+	}
+}
+
 func TestBuildDualModePaneURL(t *testing.T) {
 	artistPath := "/artists/aagaard-carl-frederik-f2540d7a3fe99f9"
 	artworkPath := "/artists/aagaard-carl-frederik-f2540d7a3fe99f9/deer-beside-a-lake-a6aab5e26c30056"

--- a/playwright-tests/dual-mode.spec.ts
+++ b/playwright-tests/dual-mode.spec.ts
@@ -30,6 +30,9 @@ const expectDualModeState = async (
 	);
 };
 
+const paneTargetControls = (page, side: string) =>
+	page.getByRole("navigation", { name: `Open ${side} links in` });
+
 test("loads an artist through the chooser and opens its artwork in the other pane", async ({
 	page,
 }) => {
@@ -42,8 +45,10 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 		"Choose content for comparison",
 	);
 	await expect(
-		page.getByLabel("Open left links in the other pane"),
-	).toBeChecked();
+		paneTargetControls(page, "left").getByRole("link", {
+			name: "Other pane",
+		}),
+	).toHaveAttribute("aria-current", "true");
 
 	await page.getByRole("button", { name: "Choose left" }).click();
 	await page.getByPlaceholder("Filter artists").fill("AACHEN");
@@ -70,13 +75,17 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 test("persists a same-pane target choice", async ({ page }) => {
 	await page.goto(`/dual-mode?left=${aachenPath}&right=default`);
 
-	const targetToggle = page.getByLabel("Open left links in the other pane");
-	await expect(targetToggle).toBeChecked();
-	await targetToggle.uncheck();
+	const leftTargets = paneTargetControls(page, "left");
+	await expect(
+		leftTargets.getByRole("link", { name: "Other pane" }),
+	).toHaveAttribute("aria-current", "true");
+	await leftTargets.getByRole("link", { name: "This pane" }).click();
 
 	await expect(page).toHaveURL(/left_render_to=left/);
 	await page.reload();
-	await expect(targetToggle).not.toBeChecked();
+	await expect(
+		leftTargets.getByRole("link", { name: "This pane" }),
+	).toHaveAttribute("aria-current", "true");
 
 	await page
 		.locator("#left")
@@ -228,6 +237,30 @@ test("loads pane paths through enhanced forms", async ({ page }) => {
 	);
 });
 
+test("updates pane targets through enhanced links", async ({ page }) => {
+	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	const leftTargets = paneTargetControls(page, "left");
+	const targetResponse = page.waitForResponse(
+		(response) =>
+			response.url().includes("/dual-mode") &&
+			response.request().headers()["hx-request"] === "true",
+	);
+	await leftTargets.getByRole("link", { name: "This pane" }).click();
+	await targetResponse;
+	await expectDualModeState(page, aachenPath, koedijckPath, "left", "left");
+	await expect(
+		leftTargets.getByRole("link", { name: "This pane" }),
+	).toHaveAttribute("aria-current", "true");
+
+	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	const rightTargets = paneTargetControls(page, "right");
+	await rightTargets.getByRole("link", { name: "This pane" }).click();
+	await expectDualModeState(page, aachenPath, koedijckPath, "right", "right");
+
+	await rightTargets.getByRole("link", { name: "Other pane" }).click();
+	await expectDualModeState(page, aachenPath, koedijckPath, "right", "left");
+});
+
 test.describe("Dual Mode operations without JavaScript", () => {
 	test.use({ javaScriptEnabled: false });
 
@@ -241,6 +274,27 @@ test.describe("Dual Mode operations without JavaScript", () => {
 		await expectDualModeState(page, koedijckPath, aachenPath);
 		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
 		await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	});
+
+	test("changes pane targets through standard hrefs", async ({ page }) => {
+		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await paneTargetControls(page, "left")
+			.getByRole("link", { name: "This pane" })
+			.click();
+		await expectDualModeState(page, aachenPath, koedijckPath, "left", "left");
+
+		await page
+			.locator("#left")
+			.getByRole("link", { name: "Learn More" })
+			.first()
+			.click();
+		await expect(page.locator("#right h1")).toContainText("KOEDIJCK, Isaack");
+
+		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await paneTargetControls(page, "right")
+			.getByRole("link", { name: "This pane" })
+			.click();
+		await expectDualModeState(page, aachenPath, koedijckPath, "right", "right");
 	});
 
 	test("loads a right pane path through a standard GET form", async ({

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -42,7 +42,6 @@ type wgaWindow = {
 	};
 	dual: {
 		openLookup: (side: string) => void;
-		setPaneTarget: (side: string, openInOtherPane: boolean) => void;
 	};
 	window: {
 		historyBack: () => void;
@@ -166,14 +165,6 @@ const deepMerge = (target: object, source: object): object => {
 	return target;
 };
 
-const paneToTarget = (side: string): string => {
-	if (side === "left") {
-		return "right";
-	}
-
-	return "left";
-};
-
 const normalizeDualPathInput = (value: string): string | null => {
 	const normalizedValue = value.trim();
 
@@ -230,13 +221,6 @@ const updateDualMode = (mutateUrl: (url: URL) => void) => {
 const setDualPane = (side: string, value: string) => {
 	updateDualMode((nextUrl) => {
 		nextUrl.searchParams.set(side, value);
-	});
-};
-
-const updatePaneTarget = (side: string, openInOtherPane: boolean) => {
-	updateDualMode((nextUrl) => {
-		const target = openInOtherPane ? paneToTarget(side) : side;
-		nextUrl.searchParams.set(`${side}_render_to`, target);
 	});
 };
 
@@ -865,9 +849,6 @@ window.wga = {
 			modal.setAttribute("data-side", side);
 			wgaInternal.func.artistSearchModal();
 			modal.showModal();
-		},
-		setPaneTarget(side: string, openInOtherPane: boolean) {
-			updatePaneTarget(side, openInOtherPane);
 		},
 	},
 	window: {


### PR DESCRIPTION
## Summary

- replace JavaScript-only per-pane target toggles with accessible server-rendered links
- preserve both pane paths and the unaffected target setting in every canonical target URL
- enhance links with HTMX while retaining direct navigation without JavaScript
- remove obsolete JavaScript target-setting helpers and expand URL/browser coverage

Closes #169
Part of #164

## Validation

- `templ generate`
- `bun run build`
- `go vet ./...`
- `go test ./... -cover`
- `bunx biome check resources/js/app.ts playwright-tests/dual-mode.spec.ts`
- `bunx prettier --check docs/features/dual-mode-legacy-parity.md`
- `mise exec -- env WGA_PROTOCOL=http WGA_HOSTNAME=127.0.0.1:18092 bunx playwright test playwright-tests/dual-mode.spec.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-pane controls in Dual Mode to open links in the current pane or the other pane.
  - Added support for switching link targets with and without JavaScript enabled.
  - Updated navigation state indicators to clearly show the active link target.

- **Bug Fixes**
  - Improved Dual Mode target selection behavior and URL state handling.

- **Tests**
  - Added coverage for target switching across enhanced and standard navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->