### PR TITLE
feat: add bounded Dual Mode artwork lookup

### DIFF
--- a/docs/features/dual-mode-legacy-parity.md
+++ b/docs/features/dual-mode-legacy-parity.md
@@ -20,7 +20,7 @@ This specification defines feature parity as preserving those user outcomes in t
 | Compare artist, artwork, and embedded biography content                                | Complete       | `internal/handlers/dual/main.go` renders artist and artwork blocks                                       |
 | Keep pane state in a reloadable/shareable URL                                          | Complete       | `left`, `right`, and `*_render_to` query parameters                                                      |
 | Choose whether supported artist/artwork links replace a pane or open in the other pane | Complete       | Per-pane labelled toggle and Playwright coverage                                                         |
-| Load content through a chooser                                                         | Partial        | A JavaScript-populated, searchable artist chooser is available; artworks require a pasted canonical path |
+| Load content through a chooser                                                         | Complete       | A bounded server-side lookup searches published artists or artworks; canonical-path forms remain a fallback |
 | Use the legacy A–Z, catalogue-section, Search, and Hints entry points in a pane        | Missing        | `parsePanePath` accepts artist and artwork detail paths only                                             |
 | Create artist lists by school, period, time-line, profession, and sort order           | Missing        | The current artist listing only supports a name query and cannot be loaded into a pane                   |
 | Copy, reverse, and clear panes                                                         | Missing        | The modern control bar has no equivalent actions                                                         |
@@ -72,7 +72,7 @@ The legacy page recommends a 1024 × 768 display. The modern view activates at 7
 
 - [x] Add progressive canonical-path forms for either pane. **Verified by:** Go URL-state coverage and JavaScript-enabled and JavaScript-disabled Playwright journeys.
 - [x] Add progressive link-target controls for either pane. **Verified by:** Go URL-state coverage and JavaScript-enabled and JavaScript-disabled Playwright journeys.
-- [ ] Add searchable artist and artwork selection for either pane. **Done when:** a visitor can select either content type without manually constructing a path.
+- [x] Add searchable artist and artwork selection for either pane. **Verified by:** bounded Go lookup coverage and artist/artwork Playwright chooser journeys.
 - [x] Add copy, reverse, and clear controls. **Verified by:** the operation-link Go and Playwright coverage, including URL state and fallback navigation.
 - [x] Add an explicit Standard view action. **Verified by:** the operation-link Playwright journey.
 - [x] Add focused Go and Playwright coverage for every pane operation and URL-state transition. **Verified by:** success, empty-pane, HTMX, and JavaScript-disabled journeys.

--- a/docs/features/dual-mode-legacy-parity.md
+++ b/docs/features/dual-mode-legacy-parity.md
@@ -14,18 +14,18 @@ This specification defines feature parity as preserving those user outcomes in t
 
 **Core comparison is ready; legacy feature parity is incomplete.** The current `/dual-mode` route already renders two independently scrollable panes, supports artist and artwork content, preserves pane state in the URL, and routes supported artist/artwork links to either pane. The remaining gaps are discovery, pane-management controls, legacy catalogue entry points, printing, and the explicit exit/music actions.
 
-| Legacy capability                                                                      | Current status | Evidence                                                                                                 |
-| -------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------- |
-| Two independently rendered and scrollable desktop panes                                | Complete       | `internal/assets/templ/pages/dual.templ`; `playwright-tests/dual-mode.spec.ts`                           |
-| Compare artist, artwork, and embedded biography content                                | Complete       | `internal/handlers/dual/main.go` renders artist and artwork blocks                                       |
-| Keep pane state in a reloadable/shareable URL                                          | Complete       | `left`, `right`, and `*_render_to` query parameters                                                      |
-| Choose whether supported artist/artwork links replace a pane or open in the other pane | Complete       | Per-pane labelled toggle and Playwright coverage                                                         |
+| Legacy capability                                                                      | Current status | Evidence                                                                                                    |
+| -------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
+| Two independently rendered and scrollable desktop panes                                | Complete       | `internal/assets/templ/pages/dual.templ`; `playwright-tests/dual-mode.spec.ts`                              |
+| Compare artist, artwork, and embedded biography content                                | Complete       | `internal/handlers/dual/main.go` renders artist and artwork blocks                                          |
+| Keep pane state in a reloadable/shareable URL                                          | Complete       | `left`, `right`, and `*_render_to` query parameters                                                         |
+| Choose whether supported artist/artwork links replace a pane or open in the other pane | Complete       | Per-pane labelled toggle and Playwright coverage                                                            |
 | Load content through a chooser                                                         | Complete       | A bounded server-side lookup searches published artists or artworks; canonical-path forms remain a fallback |
-| Use the legacy A–Z, catalogue-section, Search, and Hints entry points in a pane        | Missing        | `parsePanePath` accepts artist and artwork detail paths only                                             |
-| Create artist lists by school, period, time-line, profession, and sort order           | Missing        | The current artist listing only supports a name query and cannot be loaded into a pane                   |
-| Copy, reverse, and clear panes                                                         | Missing        | The modern control bar has no equivalent actions                                                         |
-| Explicit standard-view exit and music-selection action                                 | Missing        | No equivalent Dual Mode controls; music handler registration is disabled                                 |
-| Print two selected pages together                                                      | Missing        | No Dual Mode print experience or acceptance coverage                                                     |
+| Use the legacy A–Z, catalogue-section, Search, and Hints entry points in a pane        | Missing        | `parsePanePath` accepts artist and artwork detail paths only                                                |
+| Create artist lists by school, period, time-line, profession, and sort order           | Missing        | The current artist listing only supports a name query and cannot be loaded into a pane                      |
+| Copy, reverse, and clear panes                                                         | Missing        | The modern control bar has no equivalent actions                                                            |
+| Explicit standard-view exit and music-selection action                                 | Missing        | No equivalent Dual Mode controls; music handler registration is disabled                                    |
+| Print two selected pages together                                                      | Missing        | No Dual Mode print experience or acceptance coverage                                                        |
 
 The legacy page recommends a 1024 × 768 display. The modern view activates at 768 px; it must be visually verified at the legacy reference size before calling the desktop experience complete.
 

--- a/internal/assets/templ/dto/dto.go
+++ b/internal/assets/templ/dto/dto.go
@@ -65,22 +65,29 @@ type ArtworkSearchResultDTO struct {
 	HxTarget        string
 }
 
-type ArtistNameListEntry struct {
-	Url   string `json:"url"`
-	Label string `json:"label"`
-}
-
 type DualViewDto struct {
 	Left                      string
 	Right                     string
 	LeftLinksOpenInOtherPane  bool
 	RightLinksOpenInOtherPane bool
-	ArtistNameList            []ArtistNameListEntry
 	CopyLeftToRightUrl        string
 	CopyRightToLeftUrl        string
 	ReverseUrl                string
 	ClearLeftUrl              string
 	ClearRightUrl             string
+}
+
+type DualLookupResultDto struct {
+	Url     string
+	Label   string
+	Context string
+}
+
+type DualLookupResultsDto struct {
+	Kind          string
+	Query         string
+	QueryTooShort bool
+	Results       []DualLookupResultDto
 }
 
 type DualPaneLoadFormDto struct {

--- a/internal/assets/templ/pages/dual.templ
+++ b/internal/assets/templ/pages/dual.templ
@@ -46,9 +46,9 @@ templ DualPaneDefault(side string) {
 					<h2 class="text-2xl font-semibold">Choose content for comparison</h2>
 				</div>
 				if side == "left" {
-					<button type="button" class="btn btn-primary btn-sm" onclick="window.wga.dual.openLookup('left')">Browse artists</button>
+					<button type="button" class="btn btn-primary btn-sm" onclick="window.wga.dual.openLookup('left')">Browse collection</button>
 				} else {
-					<button type="button" class="btn btn-primary btn-sm" onclick="window.wga.dual.openLookup('right')">Browse artists</button>
+					<button type="button" class="btn btn-primary btn-sm" onclick="window.wga.dual.openLookup('right')">Browse collection</button>
 				}
 			</div>
 			<p class="mb-4 text-base-content/80">Load an artist page or an artwork page into this pane. Use the bottom controls to choose whether its links replace this pane or open in the other pane.</p>
@@ -64,7 +64,7 @@ templ DualPaneDefault(side string) {
 				<div class="rounded-box bg-base-200 p-4">
 					<h3 class="mb-2 font-medium">Start browsing</h3>
 					<ul class="list-inside list-disc space-y-1 text-sm text-base-content/80">
-						<li>Choose an artist from the bottom bar</li>
+						<li>Choose an artist or artwork from the bottom bar</li>
 						<li>Paste a canonical artist or artwork path</li>
 						<li>Set where links open for each pane</li>
 					</ul>
@@ -99,16 +99,82 @@ templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto, targets dto.Dua
 			@DualPanePathForm("right", forms.Right)
 		</section>
 	</div>
-	<dialog id="artist_lookup" class="modal">
+	<dialog id="artist_lookup" class="modal" aria-labelledby="dual-lookup-title">
 		<div class="modal-box">
-			<h3 class="text-lg font-bold">Load pane</h3>
-			<p class="py-4">Choose an artist or paste a canonical path.</p>
+			<h3 id="dual-lookup-title" class="text-lg font-bold">Load pane</h3>
+			<p class="py-4">Search published artists or artworks, or paste a canonical path.</p>
+			<div id="dual-lookup-form" class="grid gap-3">
+				<label class="form-control w-full" for="dual-lookup-kind">
+					<span class="label-text text-sm">Search for</span>
+					<select
+						class="select select-bordered w-full"
+						id="dual-lookup-kind"
+						name="kind"
+					>
+						<option value="artist">Artists</option>
+						<option value="artwork">Artworks</option>
+					</select>
+				</label>
+				<label class="form-control w-full" for="dual-lookup-query">
+					<span class="label-text text-sm">Search collection</span>
+					<input
+						autocomplete="off"
+						class="input input-bordered w-full"
+						id="dual-lookup-query"
+						name="q"
+						placeholder="Type at least two characters"
+						type="search"
+					/>
+				</label>
+			</div>
+			@DualLookupResults(dto.DualLookupResultsDto{Kind: "artist"})
+			<form id="dual-lookup-path-form" method="dialog" class="mt-4 grid gap-3 border-t border-base-300 pt-4">
+				<label class="form-control w-full" for="dual-lookup-path">
+					<span class="label-text text-sm">Canonical path</span>
+					<input
+						class="input input-bordered w-full"
+						id="dual-lookup-path"
+						placeholder="/artists/... or /artworks/..."
+						type="text"
+					/>
+				</label>
+				<button id="dual-lookup-path-submit" type="submit" class="btn btn-secondary btn-sm">Load pane</button>
+			</form>
 		</div>
 		<form method="dialog" class="modal-backdrop">
 			<button>close</button>
 		</form>
 	</dialog>
-	@templ.JSONScript("artistList", c.ArtistNameList)
+}
+
+templ DualLookupResults(c dto.DualLookupResultsDto) {
+	<div id="dual-lookup-results" class="mt-4 max-h-80 overflow-y-auto rounded-box border border-base-300" aria-live="polite">
+		@DualLookupResultContent(c)
+	</div>
+}
+
+templ DualLookupResultContent(c dto.DualLookupResultsDto) {
+	if c.Query == "" {
+		<p class="p-4 text-sm text-base-content/70">Start typing to search { c.Kind }s.</p>
+	} else if c.QueryTooShort {
+		<p class="p-4 text-sm text-base-content/70">Enter at least two characters to search.</p>
+	} else if len(c.Results) == 0 {
+		<p class="p-4 text-sm text-base-content/70">No { c.Kind }s match “{ c.Query }”.</p>
+	} else {
+		for _, result := range c.Results {
+			<button
+				type="button"
+				class="btn btn-ghost h-auto w-full justify-start rounded-none px-4 py-3 text-left"
+				data-dual-lookup-path={ result.Url }
+				data-dual-lookup-result
+			>
+				<span>{ result.Label }</span>
+				if result.Context != "" {
+					<span class="ml-2 text-sm font-normal text-base-content/70">{ result.Context }</span>
+				}
+			</button>
+		}
+	}
 }
 
 templ DualPaneTargetControls(side string, otherPaneActive bool, samePaneUrl string, otherPaneUrl string) {

--- a/internal/handlers/dual/main.go
+++ b/internal/handlers/dual/main.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"slices"
+	"fmt"
+	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/blackfyre/wga/internal/assets/templ/dto"
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
@@ -15,9 +17,9 @@ import (
 	"github.com/blackfyre/wga/internal/constants"
 	"github.com/blackfyre/wga/internal/errs"
 	"github.com/blackfyre/wga/internal/handlers/artists"
-	"github.com/blackfyre/wga/internal/handlers/artworks"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -34,6 +36,12 @@ type panePathDto struct {
 	Id      string
 	RelPath string
 }
+
+const (
+	dualLookupPath              = "/dual-mode/lookup"
+	dualLookupLimit             = 20
+	dualLookupMinimumQueryRunes = 2
+)
 
 // renderDualModePage renders the dual-mode comparison view.
 func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error {
@@ -64,15 +72,6 @@ func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error 
 	contentDto.ReverseUrl = buildDualModeActionURL(leftPane, rightPane, "reverse")
 	contentDto.ClearLeftUrl = buildDualModeActionURL(leftPane, rightPane, "clear-left")
 	contentDto.ClearRightUrl = buildDualModeActionURL(leftPane, rightPane, "clear-right")
-	contentDto.ArtistNameList = []dto.ArtistNameListEntry{}
-	artistNameList, err := artworks.GetArtistNameList(app)
-
-	if err != nil {
-		app.Logger().Error("Error getting artist name list", "error", err.Error())
-	} else {
-		contentDto.ArtistNameList = formatArtistNameList(artistNameList)
-	}
-
 	c.Response.Header().Set("HX-Push-Url", buildDualModePushURL(leftPane, rightPane))
 
 	var buff bytes.Buffer
@@ -89,6 +88,194 @@ func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error 
 	}
 
 	return c.HTML(200, buff.String())
+}
+
+func renderDualLookupResults(app *pocketbase.PocketBase, c *core.RequestEvent) error {
+	queryValues := c.Request.URL.Query()
+	content, err := getDualLookupResults(app, queryValues.Get("kind"), queryValues.Get("q"))
+
+	if err != nil {
+		app.Logger().Error("Error getting dual lookup results", "error", err.Error())
+		return utils.ServerFaultError(c)
+	}
+
+	var buff bytes.Buffer
+
+	if err := pages.DualLookupResultContent(content).Render(context.Background(), &buff); err != nil {
+		app.Logger().Error("Error rendering dual lookup results", "error", err.Error())
+		return utils.ServerFaultError(c)
+	}
+
+	return c.HTML(http.StatusOK, buff.String())
+}
+
+func getDualLookupResults(app core.App, kind string, query string) (dto.DualLookupResultsDto, error) {
+	content := dto.DualLookupResultsDto{
+		Kind:    resolveDualLookupKind(kind),
+		Query:   strings.TrimSpace(query),
+		Results: []dto.DualLookupResultDto{},
+	}
+
+	if content.Query == "" {
+		return content, nil
+	}
+
+	if utf8.RuneCountInString(content.Query) < dualLookupMinimumQueryRunes {
+		content.QueryTooShort = true
+		return content, nil
+	}
+
+	var err error
+
+	switch content.Kind {
+	case "artist":
+		content.Results, err = getArtistLookupResults(app, content.Query)
+	case "artwork":
+		content.Results, err = getArtworkLookupResults(app, content.Query)
+	}
+
+	return content, err
+}
+
+func resolveDualLookupKind(kind string) string {
+	if strings.TrimSpace(kind) == "artwork" {
+		return "artwork"
+	}
+
+	return "artist"
+}
+
+func getArtistLookupResults(app core.App, query string) ([]dto.DualLookupResultDto, error) {
+	records, err := app.FindRecordsByFilter(
+		constants.CollectionArtists,
+		"published = true && name ~ {:query}",
+		"+name,+id",
+		dualLookupLimit,
+		0,
+		dbx.Params{"query": query},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]dto.DualLookupResultDto, 0, len(records))
+
+	for _, record := range records {
+		results = append(results, dto.DualLookupResultDto{
+			Url: url.GenerateArtistUrl(url.ArtistUrlDTO{
+				ArtistId:   record.Id,
+				ArtistName: record.GetString("name"),
+			}),
+			Label: record.GetString("name"),
+		})
+	}
+
+	return results, nil
+}
+
+func getArtworkLookupResults(app core.App, query string) ([]dto.DualLookupResultDto, error) {
+	records, err := app.FindRecordsByFilter(
+		constants.CollectionArtworks,
+		"published = true && author:length > 0 && title ~ {:query}",
+		"+title,+id",
+		dualLookupLimit,
+		0,
+		dbx.Params{"query": query},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	artistsByID, err := getLookupArtistsByID(app, uniqueLookupArtistIDs(records))
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]dto.DualLookupResultDto, 0, len(records))
+
+	for _, record := range records {
+		authorIDs := record.GetStringSlice("author")
+		if len(authorIDs) == 0 {
+			continue
+		}
+
+		artist, ok := artistsByID[authorIDs[0]]
+		if !ok {
+			continue
+		}
+
+		results = append(results, dto.DualLookupResultDto{
+			Url: url.GenerateFullArtworkUrl(url.ArtworkUrlDTO{
+				ArtistId:     artist.Id,
+				ArtistName:   artist.GetString("name"),
+				ArtworkId:    record.Id,
+				ArtworkTitle: record.GetString("title"),
+			}),
+			Label:   record.GetString("title"),
+			Context: artist.GetString("name"),
+		})
+	}
+
+	return results, nil
+}
+
+func uniqueLookupArtistIDs(records []*core.Record) []string {
+	seen := map[string]struct{}{}
+	artistIDs := make([]string, 0, len(records))
+
+	for _, record := range records {
+		for _, artistID := range record.GetStringSlice("author") {
+			if artistID == "" {
+				continue
+			}
+
+			if _, exists := seen[artistID]; exists {
+				continue
+			}
+
+			seen[artistID] = struct{}{}
+			artistIDs = append(artistIDs, artistID)
+		}
+	}
+
+	return artistIDs
+}
+
+func getLookupArtistsByID(app core.App, artistIDs []string) (map[string]*core.Record, error) {
+	if len(artistIDs) == 0 {
+		return map[string]*core.Record{}, nil
+	}
+
+	params := dbx.Params{}
+	conditions := make([]string, 0, len(artistIDs))
+
+	for index, artistID := range artistIDs {
+		key := fmt.Sprintf("artist_id_%d", index)
+		conditions = append(conditions, fmt.Sprintf("id = {:%s}", key))
+		params[key] = artistID
+	}
+
+	records, err := app.FindRecordsByFilter(
+		constants.CollectionArtists,
+		strings.Join(conditions, " || "),
+		"+name,+id",
+		len(artistIDs),
+		0,
+		params,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	artistsByID := make(map[string]*core.Record, len(records))
+	for _, record := range records {
+		artistsByID[record.Id] = record
+	}
+
+	return artistsByID, nil
 }
 
 func buildDualModePushURL(leftPane renderPaneDto, rightPane renderPaneDto) string {
@@ -247,30 +434,6 @@ func parsePanePath(raw string) (panePathDto, error) {
 	default:
 		return panePathDto{}, errs.ErrUnknownDualPane
 	}
-}
-
-// formatArtistNameList formats the artist name list.
-// It takes a map of artist names as a parameter.
-// It returns a slice of dto.ArtistNameListEntry.
-func formatArtistNameList(artistNameList map[string]string) []dto.ArtistNameListEntry {
-	artistNameListEntries := make([]dto.ArtistNameListEntry, 0)
-
-	for url, label := range artistNameList {
-		artistNameListEntries = append(artistNameListEntries, dto.ArtistNameListEntry{
-			Url:   url,
-			Label: label,
-		})
-	}
-
-	slices.SortFunc(artistNameListEntries, func(a dto.ArtistNameListEntry, b dto.ArtistNameListEntry) int {
-		if diff := strings.Compare(a.Label, b.Label); diff != 0 {
-			return diff
-		}
-
-		return strings.Compare(a.Url, b.Url)
-	})
-
-	return artistNameListEntries
 }
 
 // reverseSide returns the opposite side of the given side.
@@ -452,6 +615,9 @@ func RegisterHandlers(app *pocketbase.PocketBase) {
 	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
 		se.Router.GET("/dual-mode", func(c *core.RequestEvent) error {
 			return renderDualModePage(app, c)
+		})
+		se.Router.GET(dualLookupPath, func(c *core.RequestEvent) error {
+			return renderDualLookupResults(app, c)
 		})
 		return se.Next()
 	})

--- a/internal/handlers/dual/main_test.go
+++ b/internal/handlers/dual/main_test.go
@@ -180,7 +180,7 @@ func newDualLookupTestApp(t *testing.T) *tests.TestApp {
 		&core.RelationField{
 			Name:         "author",
 			CollectionId: artists.Id,
-			MaxSelect:    1,
+			MaxSelect:    2,
 		},
 	)
 	if err := app.Save(artworks); err != nil {

--- a/internal/handlers/dual/main_test.go
+++ b/internal/handlers/dual/main_test.go
@@ -1,6 +1,9 @@
 package dual
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -8,43 +11,224 @@ import (
 	"testing"
 
 	"github.com/blackfyre/wga/internal/assets/templ/dto"
+	"github.com/blackfyre/wga/internal/assets/templ/pages"
+	"github.com/blackfyre/wga/internal/constants"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
 )
 
-func TestFormatArtistNameList(t *testing.T) {
+func TestGetDualLookupResultsRequiresTwoRunes(t *testing.T) {
+	content, err := getDualLookupResults(nil, "artwork", " é ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if content.Kind != "artwork" || content.Query != "é" || !content.QueryTooShort {
+		t.Fatalf("unexpected short lookup result: %#v", content)
+	}
+}
+
+func TestGetArtistLookupResultsIsBounded(t *testing.T) {
+	app := newDualLookupTestApp(t)
+
+	for index := range dualLookupLimit + 1 {
+		saveLookupArtist(t, app, fmt.Sprintf("Artist Lookup %02d", index), true)
+	}
+	saveLookupArtist(t, app, "Artist Lookup hidden", false)
+
+	content, err := getDualLookupResults(app, "artist", "lookup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(content.Results) != dualLookupLimit {
+		t.Fatalf("expected %d results, got %d", dualLookupLimit, len(content.Results))
+	}
+
+	for index, result := range content.Results {
+		wantLabel := fmt.Sprintf("Artist Lookup %02d", index)
+		if result.Label != wantLabel {
+			t.Fatalf("expected result %d to be %q, got %q", index, wantLabel, result.Label)
+		}
+		if !strings.HasPrefix(result.Url, "/artists/") {
+			t.Fatalf("expected canonical artist URL, got %q", result.Url)
+		}
+	}
+}
+
+func TestGetArtworkLookupResultsIsBounded(t *testing.T) {
+	app := newDualLookupTestApp(t)
+	artist := saveLookupArtist(t, app, "Lookup Artist", true)
+
+	for index := range dualLookupLimit + 1 {
+		saveLookupArtwork(t, app, artist.Id, fmt.Sprintf("Artwork Lookup %02d", index), true)
+	}
+	saveLookupArtwork(t, app, artist.Id, "Artwork Lookup hidden", false)
+
+	content, err := getDualLookupResults(app, "artwork", "lookup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(content.Results) != dualLookupLimit {
+		t.Fatalf("expected %d results, got %d", dualLookupLimit, len(content.Results))
+	}
+
+	for index, result := range content.Results {
+		wantLabel := fmt.Sprintf("Artwork Lookup %02d", index)
+		if result.Label != wantLabel {
+			t.Fatalf("expected result %d to be %q, got %q", index, wantLabel, result.Label)
+		}
+		if result.Context != "Lookup Artist" {
+			t.Fatalf("expected artist context, got %q", result.Context)
+		}
+		if !strings.HasPrefix(result.Url, "/artists/") {
+			t.Fatalf("expected canonical artwork URL, got %q", result.Url)
+		}
+	}
+}
+
+func TestGetArtworkLookupResultsIncludesAuthorContext(t *testing.T) {
+	app := newDualLookupTestApp(t)
+	firstArtist := saveLookupArtist(t, app, "First Lookup Artist", true)
+	secondArtist := saveLookupArtist(t, app, "Second Lookup Artist", true)
+	saveLookupArtworkWithAuthors(
+		t,
+		app,
+		[]string{firstArtist.Id, secondArtist.Id},
+		"Multiple Lookup Authors",
+		true,
+	)
+
+	content, err := getDualLookupResults(app, "artwork", "multiple")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(content.Results) != 1 {
+		t.Fatalf("expected one result, got %d", len(content.Results))
+	}
+
+	if content.Results[0].Context != "First Lookup Artist" && content.Results[0].Context != "Second Lookup Artist" {
+		t.Fatalf("expected associated author context, got %q", content.Results[0].Context)
+	}
+}
+
+func TestDualLookupResultsRenderAccessibleStates(t *testing.T) {
 	tests := []struct {
-		name  string
-		input map[string]string
-		want  []dto.ArtistNameListEntry
+		name    string
+		content dto.DualLookupResultsDto
+		want    string
 	}{
 		{
-			name:  "empty list",
-			input: map[string]string{},
-			want:  []dto.ArtistNameListEntry{},
+			name:    "empty query",
+			content: dto.DualLookupResultsDto{Kind: "artist"},
+			want:    "Start typing to search artists.",
 		},
 		{
-			name: "sorts by label then URL",
-			input: map[string]string{
-				"/artists/two":     "Artist Two",
-				"/artists/one":     "Artist One",
-				"/artists/one-alt": "Artist One",
+			name: "short query",
+			content: dto.DualLookupResultsDto{
+				Kind:          "artwork",
+				Query:         "a",
+				QueryTooShort: true,
 			},
-			want: []dto.ArtistNameListEntry{
-				{Url: "/artists/one", Label: "Artist One"},
-				{Url: "/artists/one-alt", Label: "Artist One"},
-				{Url: "/artists/two", Label: "Artist Two"},
-			},
+			want: "Enter at least two characters to search.",
+		},
+		{
+			name:    "no results",
+			content: dto.DualLookupResultsDto{Kind: "artist", Query: "Missing"},
+			want:    "No artists match",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := formatArtistNameList(test.input)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Fatalf("expected %#v, got %#v", test.want, got)
+			var buff bytes.Buffer
+			if err := pages.DualLookupResults(test.content).Render(context.Background(), &buff); err != nil {
+				t.Fatalf("unexpected render error: %v", err)
+			}
+
+			if !strings.Contains(buff.String(), test.want) {
+				t.Fatalf("expected %q in %q", test.want, buff.String())
 			}
 		})
 	}
+}
+
+func newDualLookupTestApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("failed to create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	artists := core.NewBaseCollection(constants.CollectionArtists)
+	artists.Fields.Add(
+		&core.TextField{Name: "name"},
+		&core.BoolField{Name: "published"},
+	)
+	if err := app.Save(artists); err != nil {
+		t.Fatalf("failed to create artists collection: %v", err)
+	}
+
+	artworks := core.NewBaseCollection(constants.CollectionArtworks)
+	artworks.Fields.Add(
+		&core.TextField{Name: "title"},
+		&core.BoolField{Name: "published"},
+		&core.RelationField{
+			Name:         "author",
+			CollectionId: artists.Id,
+			MaxSelect:    1,
+		},
+	)
+	if err := app.Save(artworks); err != nil {
+		t.Fatalf("failed to create artworks collection: %v", err)
+	}
+
+	return app
+}
+
+func saveLookupArtist(t *testing.T, app core.App, name string, published bool) *core.Record {
+	t.Helper()
+
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtists)
+	if err != nil {
+		t.Fatalf("failed to find artists collection: %v", err)
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("name", name)
+	record.Set("published", published)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("failed to save artist: %v", err)
+	}
+
+	return record
+}
+
+func saveLookupArtwork(t *testing.T, app core.App, artistID string, title string, published bool) *core.Record {
+	return saveLookupArtworkWithAuthors(t, app, []string{artistID}, title, published)
+}
+
+func saveLookupArtworkWithAuthors(t *testing.T, app core.App, artistIDs []string, title string, published bool) *core.Record {
+	t.Helper()
+
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
+	if err != nil {
+		t.Fatalf("failed to find artworks collection: %v", err)
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("author", artistIDs)
+	record.Set("published", published)
+	record.Set("title", title)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("failed to save artwork: %v", err)
+	}
+
+	return record
 }
 
 func TestReverseSide(t *testing.T) {

--- a/playwright-tests/dual-mode.spec.ts
+++ b/playwright-tests/dual-mode.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { type Route, expect, test } from "@playwright/test";
 
 const aachenPath = "/artists/aachen-hans-von-139ac2dff50d65c";
 const aachenArtworkPath =
@@ -49,9 +49,14 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 			name: "Other pane",
 		}),
 	).toHaveAttribute("aria-current", "true");
+	await expect(page.locator("#artistList")).toHaveCount(0);
 
 	await page.getByRole("button", { name: "Choose left" }).click();
-	await page.getByPlaceholder("Filter artists").fill("AACHEN");
+	const lookupResponse = page.waitForResponse((response) =>
+		response.url().includes("/dual-mode/lookup"),
+	);
+	await page.getByLabel("Search collection").fill("AACHEN");
+	await lookupResponse;
 	await page
 		.getByRole("button", { name: "AACHEN, Hans von", exact: true })
 		.click();
@@ -69,6 +74,91 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 	await expect(page.locator("#left h1")).toContainText("AACHEN, Hans von");
 	await expect(page.locator("#right")).not.toContainText(
 		"Choose content for comparison",
+	);
+});
+
+test("loads an artwork through the chooser and preserves Dual Mode state", async ({
+	page,
+}) => {
+	await page.goto(dualModeURL(aachenPath, "default", "left", "right"));
+	await page.getByRole("button", { name: "Choose right" }).click();
+	await page.getByLabel("Search for").selectOption("artwork");
+
+	const lookupResponse = page.waitForResponse((response) =>
+		response.url().includes("/dual-mode/lookup"),
+	);
+	await page.getByLabel("Search collection").fill("A Couple");
+	await lookupResponse;
+
+	const artworkResult = page.getByRole("button", {
+		name: /A Couple in a Tavern/,
+	});
+	await expect(artworkResult).toContainText("AACHEN, Hans von");
+	await artworkResult.click();
+
+	await expectDualModeState(
+		page,
+		aachenPath,
+		aachenArtworkPath,
+		"left",
+		"right",
+	);
+	await expect(page.locator("#right h1")).toContainText("A Couple in a Tavern");
+});
+
+test("shows accessible lookup query states", async ({ page }) => {
+	await page.goto("/dual-mode");
+	await page.getByRole("button", { name: "Choose left" }).click();
+
+	const results = page.locator("#dual-lookup-results");
+	await expect(results).toContainText("Start typing to search artists.");
+
+	const shortQueryResponse = page.waitForResponse((response) =>
+		response.url().includes("/dual-mode/lookup"),
+	);
+	await page.getByLabel("Search collection").fill("a");
+	await shortQueryResponse;
+	await expect(results).toContainText(
+		"Enter at least two characters to search.",
+	);
+
+	const noResultResponse = page.waitForResponse((response) =>
+		response.url().includes("/dual-mode/lookup"),
+	);
+	await page.getByLabel("Search collection").fill("wga-no-match");
+	await noResultResponse;
+	await expect(results).toContainText("No artists match");
+});
+
+test("cancels an active lookup when the chooser closes", async ({ page }) => {
+	let delayedRoute: Route | null = null;
+	await page.route("**/dual-mode/lookup**", (route) => {
+		delayedRoute = route;
+	});
+
+	await page.goto("/dual-mode");
+	await page.getByRole("button", { name: "Choose left" }).click();
+
+	const lookupRequest = page.waitForRequest((request) =>
+		request.url().includes("/dual-mode/lookup"),
+	);
+	await page.getByLabel("Search collection").fill("AACHEN");
+	await lookupRequest;
+	await expect.poll(() => delayedRoute).not.toBeNull();
+	await page.keyboard.press("Escape");
+
+	if (!delayedRoute) {
+		throw new Error("Expected delayed lookup route");
+	}
+
+	await delayedRoute.fulfill({
+		body: "<p>Delayed lookup result</p>",
+		contentType: "text/html",
+	});
+	await page.waitForTimeout(100);
+
+	await expect(page.locator("#dual-lookup-results")).toContainText(
+		"Start typing to search artists.",
 	);
 });
 

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -68,7 +68,7 @@ type wgaInternals = {
 		cloner: () => void;
 		viewer: () => void;
 		toast: (message: string, type: ToastEvent["detail"]["type"]) => void;
-		artistSearchModal: () => void;
+		dualLookupModal: () => void;
 		glossary: () => void;
 		init: () => void;
 	};
@@ -346,6 +346,125 @@ const maybeInitStatisticsCharts = async () => {
 	}
 };
 
+const dualLookupFailureContent =
+	'<p class="p-4 text-sm text-base-content/70">Unable to load lookup results.</p>';
+
+const requestDualLookupResults = async (
+	kind: string,
+	query: string,
+	signal: AbortSignal,
+) => {
+	try {
+		const parameters = new URLSearchParams({ kind, q: query });
+		const response = await fetch(`/dual-mode/lookup?${parameters}`, { signal });
+		if (!response.ok) {
+			return null;
+		}
+
+		return response.text();
+	} catch {
+		return null;
+	}
+};
+
+const bindDualLookupSearch = (
+	kindInput: HTMLSelectElement,
+	queryInput: HTMLInputElement,
+	results: HTMLElement,
+) => {
+	let lookupRequest: AbortController | null = null;
+	let lookupTimeout: number | undefined;
+	let lookupVersion = 0;
+
+	const loadResults = async (version: number) => {
+		const request = new AbortController();
+		lookupRequest = request;
+
+		const content = await requestDualLookupResults(
+			kindInput.value,
+			queryInput.value,
+			request.signal,
+		);
+		if (version !== lookupVersion) {
+			return;
+		}
+
+		if (content === null) {
+			results.innerHTML = dualLookupFailureContent;
+			return;
+		}
+
+		results.innerHTML = content;
+	};
+
+	const cancelLookup = () => {
+		lookupVersion += 1;
+		lookupRequest?.abort();
+
+		if (lookupTimeout !== undefined) {
+			window.clearTimeout(lookupTimeout);
+		}
+	};
+
+	const scheduleLookup = () => {
+		cancelLookup();
+		const version = lookupVersion;
+		lookupTimeout = window.setTimeout(() => {
+			void loadResults(version);
+		}, 250);
+	};
+
+	kindInput.addEventListener("change", scheduleLookup);
+	queryInput.addEventListener("input", scheduleLookup);
+	queryInput.addEventListener("search", scheduleLookup);
+
+	return cancelLookup;
+};
+
+const bindDualLookupPathForm = (
+	modal: HTMLDialogElement,
+	pathForm: HTMLFormElement,
+	pathInput: HTMLInputElement,
+	cancelLookup: () => void,
+) => {
+	pathForm.addEventListener("submit", (event) => {
+		event.preventDefault();
+
+		const normalizedPath = normalizeDualPathInput(pathInput.value);
+		if (!normalizedPath) {
+			wgaInternal.func.toast(
+				"Use a canonical /artists/... or /artworks/... path.",
+				"warning",
+			);
+			return;
+		}
+
+		cancelLookup();
+		setDualPane(modal.dataset.side || "left", normalizedPath);
+		modal.close();
+	});
+};
+
+const bindDualLookupResultSelection = (
+	modal: HTMLDialogElement,
+	cancelLookup: () => void,
+) => {
+	modal.addEventListener("click", (event) => {
+		if (!(event.target instanceof Element)) {
+			return;
+		}
+
+		const result = event.target.closest<HTMLElement>("[data-dual-lookup-path]");
+		if (!result?.dataset.dualLookupPath) {
+			return;
+		}
+
+		cancelLookup();
+		setDualPane(modal.dataset.side || "left", result.dataset.dualLookupPath);
+		modal.close();
+	});
+};
+
 const wgaInternal: wgaInternals = {
 	els: {
 		dialog: null,
@@ -379,7 +498,7 @@ const wgaInternal: wgaInternals = {
 			document.body.addEventListener("htmx:load", () => {
 				wgaInternal.func.viewer();
 				wgaInternal.func.cloner();
-				wgaInternal.func.artistSearchModal();
+				wgaInternal.func.dualLookupModal();
 				wgaInternal.func.glossary();
 				void maybeInitStatisticsCharts();
 			});
@@ -670,120 +789,36 @@ const wgaInternal: wgaInternals = {
 				});
 			}
 		},
-		artistSearchModal() {
-			const artistSearchModal = document.getElementById("artist_lookup");
-
-			if (!artistSearchModal) {
+		dualLookupModal() {
+			const modal = document.getElementById(
+				"artist_lookup",
+			) as HTMLDialogElement | null;
+			if (!modal || modal.dataset.lookupBound === "true") {
 				return;
 			}
 
-			//find .modal-box in the modal
-			const modalBox = artistSearchModal.querySelector(".modal-box");
+			const kindInput = document.getElementById(
+				"dual-lookup-kind",
+			) as HTMLSelectElement;
+			const queryInput = document.getElementById(
+				"dual-lookup-query",
+			) as HTMLInputElement;
+			const results = document.getElementById(
+				"dual-lookup-results",
+			) as HTMLElement;
+			const pathForm = document.getElementById(
+				"dual-lookup-path-form",
+			) as HTMLFormElement;
+			const pathInput = document.getElementById(
+				"dual-lookup-path",
+			) as HTMLInputElement;
 
-			if (!modalBox) {
-				logger.error("Modal box not found");
-				return;
-			}
+			const cancelLookup = bindDualLookupSearch(kindInput, queryInput, results);
+			bindDualLookupPathForm(modal, pathForm, pathInput, cancelLookup);
+			bindDualLookupResultSelection(modal, cancelLookup);
+			modal.addEventListener("close", cancelLookup);
 
-			// get the contents of #artistList and parse it as json
-			const artistList = document.getElementById("artistList");
-			if (!artistList) {
-				logger.error("Artist list not found");
-				return;
-			}
-
-			const artists = JSON.parse(artistList.innerHTML);
-
-			const side = artistSearchModal.getAttribute("data-side") || "left";
-
-			const searchInput = document.createElement("input");
-			searchInput.type = "search";
-			searchInput.placeholder = "Filter artists";
-			searchInput.className = "input input-bordered w-full";
-
-			const pathInput = document.createElement("input");
-			pathInput.type = "text";
-			pathInput.placeholder = "/artists/... or /artworks/...";
-			pathInput.className = "input input-bordered w-full";
-
-			const pathButton = document.createElement("button");
-			pathButton.type = "button";
-			pathButton.className = "btn btn-secondary btn-sm";
-			pathButton.textContent = `Load ${side} pane`;
-
-			const resultList = document.createElement("div");
-			resultList.className =
-				"mt-4 max-h-80 overflow-y-auto rounded-box border border-base-300";
-
-			const renderArtistButtons = (filterValue: string) => {
-				resultList.innerHTML = "";
-
-				const filteredArtists = artists.filter(
-					(artist: { label: string; url: string }) =>
-						artist.label.toLowerCase().includes(filterValue.toLowerCase()),
-				);
-
-				if (filteredArtists.length === 0) {
-					const emptyState = document.createElement("p");
-					emptyState.className = "p-4 text-sm text-base-content/70";
-					emptyState.textContent = "No artists match that filter.";
-					resultList.appendChild(emptyState);
-					return;
-				}
-
-				for (const artist of filteredArtists) {
-					const button = document.createElement("button");
-					button.type = "button";
-					button.className =
-						"btn btn-ghost h-auto w-full justify-start rounded-none px-4 py-3 text-left";
-					button.textContent = artist.label;
-					button.addEventListener("click", () => {
-						setDualPane(side, artist.url);
-						(artistSearchModal as HTMLDialogElement).close();
-					});
-					resultList.appendChild(button);
-				}
-			};
-
-			searchInput.addEventListener("input", () => {
-				renderArtistButtons(searchInput.value);
-			});
-
-			pathButton.addEventListener("click", () => {
-				const normalizedPath = normalizeDualPathInput(pathInput.value);
-
-				if (!normalizedPath) {
-					wgaInternal.func.toast(
-						"Use a canonical /artists/... or /artworks/... path.",
-						"warning",
-					);
-					return;
-				}
-
-				setDualPane(side, normalizedPath);
-				(artistSearchModal as HTMLDialogElement).close();
-			});
-
-			// replace the contents of the dialog with the table
-			modalBox.innerHTML = "";
-
-			const modalTitle = document.createElement("h2");
-			modalTitle.className = "mb-2 text-xl font-semibold";
-			modalTitle.textContent = `Load ${side} pane`;
-			const modalText = document.createElement("p");
-			modalText.className = "mb-4 text-sm text-base-content/70";
-			modalText.textContent =
-				"Pick an artist from the list or paste a canonical artist or artwork path.";
-			modalBox.appendChild(modalTitle);
-			modalBox.appendChild(modalText);
-			modalBox.appendChild(searchInput);
-			modalBox.appendChild(document.createElement("div")).className = "h-3";
-			modalBox.appendChild(pathInput);
-			modalBox.appendChild(document.createElement("div")).className = "h-3";
-			modalBox.appendChild(pathButton);
-			modalBox.appendChild(resultList);
-
-			renderArtistButtons("");
+			modal.dataset.lookupBound = "true";
 		},
 	},
 
@@ -847,8 +882,20 @@ window.wga = {
 			}
 
 			modal.setAttribute("data-side", side);
-			wgaInternal.func.artistSearchModal();
+			const title = document.getElementById("dual-lookup-title");
+			const pathSubmit = document.getElementById("dual-lookup-path-submit");
+
+			if (title) {
+				title.textContent = `Load ${side} pane`;
+			}
+
+			if (pathSubmit) {
+				pathSubmit.textContent = `Load ${side} pane`;
+			}
+
+			wgaInternal.func.dualLookupModal();
 			modal.showModal();
+			document.getElementById("dual-lookup-query")?.focus();
 		},
 	},
 	window: {


### PR DESCRIPTION
## Summary
- Replace the embedded artist catalogue with bounded server-side artist and artwork lookup.
- Preserve pane URL state, cancel stale lookup work, and retain canonical-path fallback forms.
- Add Go and Playwright coverage for limits, states, artwork context, and cancellation.

Closes #171

## Testing
- `go mod tidy && go vet ./... && go test ./... -cover`
- `bunx biome check resources/js/app.ts playwright-tests/dual-mode.spec.ts`
- `bunx playwright test playwright-tests/dual-mode.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded the dual-pane collection browser: “Browse” now supports searching and loading artists or artworks via a kind selector.
  * Added a new lookup dialog with results rendering, including artist context for artwork lookups.
  * Kept canonical-path loading as an alternative selection method.
  * Updated on-screen guidance for empty, too-short, and no-match queries, and preserved dual-pane state across actions.
* **Bug Fixes**
  * Improved in-progress lookup cancellation when closing the selection dialog.
* **Documentation**
  * Updated dual-mode legacy parity readiness progress.
* **Tests**
  * Extended unit and end-to-end coverage for lookup bounds, context, accessible messaging, and pane behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->