### PR TITLE
feat: load artwork search results into Dual Mode

### DIFF
--- a/docs/features/dual-mode-legacy-parity.md
+++ b/docs/features/dual-mode-legacy-parity.md
@@ -12,7 +12,7 @@ This specification defines feature parity as preserving those user outcomes in t
 
 ### Current readiness
 
-**Core comparison is ready; legacy feature parity is incomplete.** The current `/dual-mode` route already renders two independently scrollable panes, supports artist and artwork content, preserves pane state in the URL, and routes supported artist/artwork links to either pane. The remaining gaps are discovery, pane-management controls, legacy catalogue entry points, printing, and the explicit exit/music actions.
+**Core comparison is ready; legacy feature parity is incomplete.** The current `/dual-mode` route already renders two independently scrollable panes, supports artist and artwork content, preserves pane state in the URL, and routes supported artist/artwork links to either pane. The remaining gaps are catalogue discovery, artist-list filtering, printing, and the final accessibility and desktop review.
 
 | Legacy capability                                                                      | Current status | Evidence                                                                                                    |
 | -------------------------------------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -21,10 +21,10 @@ This specification defines feature parity as preserving those user outcomes in t
 | Keep pane state in a reloadable/shareable URL                                          | Complete       | `left`, `right`, and `*_render_to` query parameters                                                         |
 | Choose whether supported artist/artwork links replace a pane or open in the other pane | Complete       | Per-pane labelled toggle and Playwright coverage                                                            |
 | Load content through a chooser                                                         | Complete       | A bounded server-side lookup searches published artists or artworks; canonical-path forms remain a fallback |
-| Use the legacy A–Z, catalogue-section, Search, and Hints entry points in a pane        | Missing        | `parsePanePath` accepts artist and artwork detail paths only                                                |
+| Use the legacy A–Z, catalogue-section, Search, and Hints entry points in a pane        | Partial        | Artwork Search returns a selected result to a pane; the other entry points remain unsupported               |
 | Create artist lists by school, period, time-line, profession, and sort order           | Missing        | The current artist listing only supports a name query and cannot be loaded into a pane                      |
-| Copy, reverse, and clear panes                                                         | Missing        | The modern control bar has no equivalent actions                                                            |
-| Explicit standard-view exit and music-selection action                                 | Missing        | No equivalent Dual Mode controls; music handler registration is disabled                                    |
+| Copy, reverse, and clear panes                                                         | Complete       | URL-backed pane operations in `internal/assets/templ/pages/dual.templ` and Playwright coverage              |
+| Explicit standard-view exit and music-selection action                                 | Complete       | Standard view links to `/`; unavailable Music selection is intentionally omitted                            |
 | Print two selected pages together                                                      | Missing        | No Dual Mode print experience or acceptance coverage                                                        |
 
 The legacy page recommends a 1024 × 768 display. The modern view activates at 768 px; it must be visually verified at the legacy reference size before calling the desktop experience complete.
@@ -81,7 +81,7 @@ The legacy page recommends a 1024 × 768 display. The modern view activates at 7
 
 - [ ] Make the modern equivalents of the legacy A–Z, artist-list, period, Decorative Arts, Architecture, Search, and Hints entry points loadable into a selected pane, or document an intentional product exclusion for each unavailable content type. **Done when:** no visible Dual Mode entry point leads to unsupported content.
 - [ ] Audit whether school, period, time-line, profession, and sort data are available in the modern catalogue; implement each supported filter or document its exclusion. **Done when:** every legacy filter has a backed query or an explicit product decision, and supported filter results are shareable and usable from Dual Mode.
-- [ ] Provide a dual-safe search route or per-pane search control. **Done when:** a result can be selected into the intended pane from a keyboard-accessible search flow.
+- [x] Provide a dual-safe artwork search route. **Verified by:** Dual Mode artwork-search journeys preserve both panes and target settings with JavaScript enabled and disabled.
 - [ ] Add integration and browser coverage for discovery paths. **Done when:** one path from each supported catalogue entry point loads content into the selected pane.
 
 ### Phase 3 — Supporting parity outcomes
@@ -97,10 +97,10 @@ The legacy page recommends a 1024 × 768 display. The modern view activates at 7
 
 - [ ] A visitor can independently load and compare two artists, two artworks, or an artist and an artwork.
 - [ ] A visitor can use supported catalogue, Search, and Hints entry points to load content into either pane without pasting a path.
-- [ ] Copy, reverse, and clear operations are available, accessible, and reflected in the URL.
+- [x] Copy, reverse, and clear operations are available, accessible, and reflected in the URL.
 - [ ] Link-target settings, pane state, and operations survive reload and sharing.
 - [ ] Each legacy artist-list filter has a backed, reproducible result or an explicit documented exclusion; supported results can be used from Dual Mode.
-- [ ] The UI includes an explicit standard-view exit and no unavailable music action.
+- [x] The UI includes an explicit standard-view exit and no unavailable music action.
 - [ ] A4-landscape print preview produces two usable panes on one sheet; desktop layout is separately verified at 1024 × 768 or higher.
 - [ ] Desktop, small-screen fallback, keyboard, and screen-reader behaviour have focused automated checks or a documented manual accessibility procedure.
 

--- a/internal/assets/templ/dto/dto.go
+++ b/internal/assets/templ/dto/dto.go
@@ -44,6 +44,8 @@ type ArtworkSearchDTO struct {
 	ActiveFilterValues *ArtworkSearchFilterValues
 	ArtistNameList     map[string]string
 	NewFilterValues    string
+	ClearUrl           string
+	DualModeContext    *ArtworkSearchDualModeDto
 	Results            ArtworkSearchResultDTO
 	HxTarget           string
 }
@@ -63,6 +65,16 @@ type ArtworkSearchResultDTO struct {
 	ResultSummary   string
 	Pagination      string
 	HxTarget        string
+	DualModeUrls    map[string]string
+	DualModeTarget  string
+}
+
+type ArtworkSearchDualModeDto struct {
+	LeftPath      string
+	RightPath     string
+	LeftRenderTo  string
+	RightRenderTo string
+	Target        string
 }
 
 type DualViewDto struct {
@@ -70,6 +82,8 @@ type DualViewDto struct {
 	Right                     string
 	LeftLinksOpenInOtherPane  bool
 	RightLinksOpenInOtherPane bool
+	ArtworkSearchLeftUrl      string
+	ArtworkSearchRightUrl     string
 	CopyLeftToRightUrl        string
 	CopyRightToLeftUrl        string
 	ReverseUrl                string

--- a/internal/assets/templ/pages/artworks.templ
+++ b/internal/assets/templ/pages/artworks.templ
@@ -25,6 +25,13 @@ templ ArtworkSeachFilterBlock(b dto.ArtworkSearchDTO) {
 		method="GET"
 		class="flex flex-col gap-4 rounded-box border border-base-300 bg-base-100 p-4 shadow-sm"
 	>
+		if b.DualModeContext != nil {
+			<input type="hidden" name="dual_left" value={ b.DualModeContext.LeftPath }/>
+			<input type="hidden" name="dual_right" value={ b.DualModeContext.RightPath }/>
+			<input type="hidden" name="dual_left_render_to" value={ b.DualModeContext.LeftRenderTo }/>
+			<input type="hidden" name="dual_right_render_to" value={ b.DualModeContext.RightRenderTo }/>
+			<input type="hidden" name="dual_target" value={ b.DualModeContext.Target }/>
+		}
 		<div class="space-y-1">
 			<h2 class="text-lg font-semibold">Search the collection</h2>
 			<p class="text-sm text-base-content/70">Combine keywords and dropdown filters, then run a search when you are ready.</p>
@@ -98,7 +105,7 @@ templ ArtworkSeachFilterBlock(b dto.ArtworkSearchDTO) {
 		</label>
 		<div class="flex flex-wrap gap-2 pt-2">
 			<button type="submit" class="btn btn-primary">Search</button>
-			<a class="btn btn-ghost" href="/artworks" hx-get="/artworks" hx-target="#mc-area" hx-select="#mc-area" hx-swap="outerHTML">Clear</a>
+			<a class="btn btn-ghost" href={ b.ClearUrl } hx-get={ b.ClearUrl } hx-target="#mc-area" hx-select="#mc-area" hx-swap="outerHTML">Clear</a>
 		</div>
 		<div id="artwork-search-indicator" class="htmx-indicator rounded-box border border-base-300 bg-base-200/70 p-3 text-sm text-base-content/80">
 			Searching the collection...
@@ -140,7 +147,11 @@ templ ArtworkSearchResults(r dto.ArtworkSearchResultDTO) {
 			</div>
 		}
 		if len(r.Artworks) > 0 {
-			@components.ImageGridComponent(r.Artworks, true)
+			if r.DualModeTarget != "" {
+				@ArtworkSearchDualModeResultGrid(r.Artworks, r.DualModeUrls, r.DualModeTarget)
+			} else {
+				@components.ImageGridComponent(r.Artworks, true)
+			}
 		} else if !r.ActiveFiltering {
 			<div role="alert" class="alert alert-info">
 				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 rotate-90 md:rotate-0">
@@ -160,6 +171,23 @@ templ ArtworkSearchResults(r dto.ArtworkSearchResultDTO) {
 			<nav class="pagination box" role="navigation" aria-label="pagination">
 				@templ.Raw(r.Pagination)
 			</nav>
+		}
+	</div>
+}
+
+templ ArtworkSearchDualModeResultGrid(artworks dto.ImageGrid, dualModeUrls map[string]string, target string) {
+	<div class="grid gird-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4" data-viewer>
+		for _, artwork := range artworks {
+			<div class="flex flex-col gap-2">
+				@components.ImageCard(artwork, true)
+				if dualModeUrls[artwork.Id] != "" {
+					<a
+						class="btn btn-outline"
+						href={ templ.SafeURL(dualModeUrls[artwork.Id]) }
+						aria-label={ "Open " + artwork.Title + " in " + target + " pane" }
+					>Open in { target } pane</a>
+				}
+			</div>
 		}
 	</div>
 }

--- a/internal/assets/templ/pages/artworks.templ
+++ b/internal/assets/templ/pages/artworks.templ
@@ -176,7 +176,7 @@ templ ArtworkSearchResults(r dto.ArtworkSearchResultDTO) {
 }
 
 templ ArtworkSearchDualModeResultGrid(artworks dto.ImageGrid, dualModeUrls map[string]string, target string) {
-	<div class="grid gird-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4" data-viewer>
+	<div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4" data-viewer>
 		for _, artwork := range artworks {
 			<div class="flex flex-col gap-2">
 				@components.ImageCard(artwork, true)

--- a/internal/assets/templ/pages/dual.templ
+++ b/internal/assets/templ/pages/dual.templ
@@ -79,10 +79,12 @@ templ DualNav(c dto.DualViewDto, forms dto.DualPaneLoadFormsDto, targets dto.Dua
 		<div class="flex flex-wrap items-center justify-between gap-4">
 			<div class="flex items-center gap-2">
 				<button type="button" class="btn btn-sm" onclick="window.wga.dual.openLookup('left')">Choose left</button>
+				<a class="btn btn-sm" href={ c.ArtworkSearchLeftUrl }>Search left artworks</a>
 				@DualPaneTargetControls("left", c.LeftLinksOpenInOtherPane, targets.LeftSamePaneUrl, targets.LeftOtherPaneUrl)
 			</div>
 			<div class="flex items-center gap-2">
 				<button type="button" class="btn btn-sm" onclick="window.wga.dual.openLookup('right')">Choose right</button>
+				<a class="btn btn-sm" href={ c.ArtworkSearchRightUrl }>Search right artworks</a>
 				@DualPaneTargetControls("right", c.RightLinksOpenInOtherPane, targets.RightSamePaneUrl, targets.RightOtherPaneUrl)
 			</div>
 		</div>

--- a/internal/handlers/artists/artworks.go
+++ b/internal/handlers/artists/artworks.go
@@ -159,7 +159,7 @@ func processArtwork(c *core.RequestEvent, app *pocketbase.PocketBase) error {
 
 	content.Jsonld = fmt.Sprintf(`<script type="application/ld+json">%s</script>`, marshalled)
 
-	ctx := tmplUtils.DecorateContext(context.Background(), tmplUtils.TitleKey, fmt.Sprintf("%s - %s", content.Title, content.Artist.Name))
+	ctx := tmplUtils.DecorateContext(context.Background(), tmplUtils.TitleKey, fmt.Sprintf("%s - %s", content.Title, content.Name))
 	ctx = tmplUtils.DecorateContext(ctx, tmplUtils.DescriptionKey, aw.GetString("comment"))
 	ctx = tmplUtils.DecorateContext(ctx, tmplUtils.CanonicalUrlKey, expectedPageUrl)
 	ctx = tmplUtils.DecorateContext(ctx, tmplUtils.OgImageKey, utils.AssetUrl(content.Image.Image))

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -2,6 +2,7 @@ package artworks
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
@@ -24,10 +25,11 @@ func searchPage(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	fullUrl := utils.AssetUrl(c.Request.URL.String())
 	pushUrl := utils.GenerateCurrentRelativePageUrl(c)
 	filters := buildFilters(c)
+	dualModeContext := getDualModeSearchContext(c)
 
 	if filters.AnyFilterActive() {
 		// redirect to the search results page
-		return c.Redirect(http.StatusFound, filters.BuildPath("/artworks/results"))
+		return c.Redirect(http.StatusFound, buildArtworkSearchPath("/artworks/results", filters, dualModeContext))
 	}
 
 	content := dto.ArtworkSearchDTO{
@@ -38,7 +40,9 @@ func searchPage(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 			ArtTypeString: filters.ArtTypeString,
 			ArtistString:  filters.ArtistString,
 		},
-		HxTarget: "#artwork-search-results",
+		ClearUrl:        buildArtworkSearchClearPath(dualModeContext),
+		DualModeContext: dualModeContext,
+		HxTarget:        "#artwork-search-results",
 		Results: dto.ArtworkSearchResultDTO{
 			ResultSummary: "Use the filters below, then run a search to browse matching artworks.",
 		},
@@ -91,6 +95,7 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 
 	//build filters
 	filters := buildFilters(c)
+	dualModeContext := getDualModeSearchContext(c)
 
 	filterString, filterParams := filters.BuildFilter()
 
@@ -126,7 +131,9 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	recordsCount := len(totalRecords)
 
 	content := dto.ArtworkSearchDTO{
-		HxTarget: "#artwork-search-results",
+		HxTarget:        "#artwork-search-results",
+		ClearUrl:        buildArtworkSearchClearPath(dualModeContext),
+		DualModeContext: dualModeContext,
 		Results: dto.ArtworkSearchResultDTO{
 			Artworks: dto.ImageGrid{},
 		},
@@ -137,6 +144,11 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 			ArtTypeString: filters.ArtTypeString,
 			ArtistString:  filters.ArtistString,
 		},
+	}
+
+	if dualModeContext != nil {
+		content.Results.DualModeUrls = map[string]string{}
+		content.Results.DualModeTarget = dualModeContext.Target
 	}
 
 	content.ArtFormOptions, _ = getArtFormOptions(app)
@@ -179,7 +191,7 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 			thumbURL = url.GenerateThumbUrl(constants.CollectionArtworks, v.GetString("id"), imageName, "320x240", "")
 		}
 
-		content.Results.Artworks = append(content.Results.Artworks, dto.Image{
+		artwork := dto.Image{
 			Url: url.GenerateFullArtworkUrl(url.ArtworkUrlDTO{
 				ArtistName:   artist.GetString("name"),
 				ArtistId:     artist.GetString("id"),
@@ -201,11 +213,17 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 				}),
 				Profession: artist.GetString("profession"),
 			},
-		})
+		}
+
+		content.Results.Artworks = append(content.Results.Artworks, artwork)
+
+		if dualModeContext != nil {
+			content.Results.DualModeUrls[artwork.Id] = buildDualModeArtworkURL(artwork.Url, dualModeContext)
+		}
 	}
 
-	pUrl := filters.BuildPath("/artworks")
-	pHtmxUrl := filters.BuildPath("/artworks/results")
+	pUrl := buildArtworkSearchPath("/artworks", filters, dualModeContext)
+	pHtmxUrl := buildArtworkSearchPath("/artworks/results", filters, dualModeContext)
 
 	pagination := utils.NewPagination(recordsCount, limit, page, pUrl, "artwork-search-results", pHtmxUrl)
 
@@ -231,6 +249,79 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	}
 
 	return c.HTML(http.StatusOK, buff.String())
+}
+
+func getDualModeSearchContext(c *core.RequestEvent) *dto.ArtworkSearchDualModeDto {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return nil
+	}
+
+	queryValues := c.Request.URL.Query()
+	target := strings.TrimSpace(queryValues.Get("dual_target"))
+	if target != "left" && target != "right" {
+		return nil
+	}
+
+	return &dto.ArtworkSearchDualModeDto{
+		LeftPath:      cmp.Or(strings.TrimSpace(queryValues.Get("dual_left")), "default"),
+		RightPath:     cmp.Or(strings.TrimSpace(queryValues.Get("dual_right")), "default"),
+		LeftRenderTo:  resolveDualModeSearchRenderTo("left", queryValues.Get("dual_left_render_to")),
+		RightRenderTo: resolveDualModeSearchRenderTo("right", queryValues.Get("dual_right_render_to")),
+		Target:        target,
+	}
+}
+
+func resolveDualModeSearchRenderTo(side string, renderTo string) string {
+	renderTo = strings.TrimSpace(renderTo)
+	if renderTo == "left" || renderTo == "right" {
+		return renderTo
+	}
+
+	if side == "left" {
+		return "right"
+	}
+
+	return "left"
+}
+
+func buildArtworkSearchClearPath(dualModeContext *dto.ArtworkSearchDualModeDto) string {
+	return buildArtworkSearchPath("/artworks", &filters{}, dualModeContext)
+}
+
+func buildArtworkSearchPath(basePath string, filters *filters, dualModeContext *dto.ArtworkSearchDualModeDto) string {
+	if dualModeContext == nil {
+		return filters.BuildPath(basePath)
+	}
+
+	queryValues := filters.queryValues()
+	queryValues.Set("dual_left", dualModeContext.LeftPath)
+	queryValues.Set("dual_right", dualModeContext.RightPath)
+	queryValues.Set("dual_left_render_to", dualModeContext.LeftRenderTo)
+	queryValues.Set("dual_right_render_to", dualModeContext.RightRenderTo)
+	queryValues.Set("dual_target", dualModeContext.Target)
+
+	return basePath + "?" + queryValues.Encode()
+}
+
+func buildDualModeArtworkURL(artworkURL string, dualModeContext *dto.ArtworkSearchDualModeDto) string {
+	dualModeURL := url.GenerateDualModeUrl()
+	queryValues := dualModeURL.Query()
+	leftPath := dualModeContext.LeftPath
+	rightPath := dualModeContext.RightPath
+
+	if dualModeContext.Target == "left" {
+		leftPath = artworkURL
+	} else {
+		rightPath = artworkURL
+	}
+
+	queryValues.Set("left", leftPath)
+	queryValues.Set("right", rightPath)
+	queryValues.Set("left_render_to", dualModeContext.LeftRenderTo)
+	queryValues.Set("right_render_to", dualModeContext.RightRenderTo)
+	dualModeURL.RawQuery = queryValues.Encode()
+
+	return dualModeURL.String()
 }
 
 func buildResultsSummary(recordsCount int, hasActiveFilters bool) string {

--- a/internal/handlers/artworks/main_test.go
+++ b/internal/handlers/artworks/main_test.go
@@ -1,0 +1,111 @@
+package artworks
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/blackfyre/wga/internal/assets/templ/dto"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func TestGetDualModeSearchContext(t *testing.T) {
+	event := &core.RequestEvent{}
+	event.Request = httptest.NewRequest(
+		"GET",
+		"/artworks?dual_left=/artists/left-123&dual_right=/artworks/right-456&dual_left_render_to=left&dual_right_render_to=right&dual_target=right",
+		nil,
+	)
+
+	got := getDualModeSearchContext(event)
+	if got == nil {
+		t.Fatal("expected Dual Mode search context")
+	}
+
+	want := &dto.ArtworkSearchDualModeDto{
+		LeftPath:      "/artists/left-123",
+		RightPath:     "/artworks/right-456",
+		LeftRenderTo:  "left",
+		RightRenderTo: "right",
+		Target:        "right",
+	}
+
+	if *got != *want {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}
+
+func TestGetDualModeSearchContextRequiresTarget(t *testing.T) {
+	event := &core.RequestEvent{}
+	event.Request = httptest.NewRequest("GET", "/artworks?dual_left=/artists/left-123", nil)
+
+	if got := getDualModeSearchContext(event); got != nil {
+		t.Fatalf("expected no Dual Mode search context, got %#v", got)
+	}
+}
+
+func TestBuildArtworkSearchPathPreservesDualModeContext(t *testing.T) {
+	dualModeContext := &dto.ArtworkSearchDualModeDto{
+		LeftPath:      "/artists/left-123",
+		RightPath:     "/artworks/right-456",
+		LeftRenderTo:  "left",
+		RightRenderTo: "right",
+		Target:        "right",
+	}
+
+	searchURL, err := url.Parse(buildArtworkSearchPath("/artworks/results", &filters{
+		Title: "A Couple",
+		Page:  "2",
+	}, dualModeContext))
+	if err != nil {
+		t.Fatalf("expected valid search URL: %v", err)
+	}
+
+	if searchURL.Path != "/artworks/results" {
+		t.Fatalf("expected /artworks/results path, got %q", searchURL.Path)
+	}
+
+	for key, want := range map[string]string{
+		"title":                "A Couple",
+		"page":                 "2",
+		"dual_left":            dualModeContext.LeftPath,
+		"dual_right":           dualModeContext.RightPath,
+		"dual_left_render_to":  dualModeContext.LeftRenderTo,
+		"dual_right_render_to": dualModeContext.RightRenderTo,
+		"dual_target":          dualModeContext.Target,
+	} {
+		if got := searchURL.Query().Get(key); got != want {
+			t.Errorf("expected %s=%q, got %q", key, want, got)
+		}
+	}
+}
+
+func TestBuildDualModeArtworkURL(t *testing.T) {
+	dualModeContext := &dto.ArtworkSearchDualModeDto{
+		LeftPath:      "/artists/left-123",
+		RightPath:     "/artworks/right-456",
+		LeftRenderTo:  "left",
+		RightRenderTo: "right",
+		Target:        "right",
+	}
+
+	dualModeURL, err := url.Parse(buildDualModeArtworkURL("/artworks/selected-789", dualModeContext))
+	if err != nil {
+		t.Fatalf("expected valid Dual Mode URL: %v", err)
+	}
+
+	if dualModeURL.Path != "/dual-mode" {
+		t.Fatalf("expected /dual-mode path, got %q", dualModeURL.Path)
+	}
+
+	for key, want := range map[string]string{
+		"left":            dualModeContext.LeftPath,
+		"right":           "/artworks/selected-789",
+		"left_render_to":  dualModeContext.LeftRenderTo,
+		"right_render_to": dualModeContext.RightRenderTo,
+	} {
+		if got := dualModeURL.Query().Get(key); got != want {
+			t.Errorf("expected %s=%q, got %q", key, want, got)
+		}
+	}
+}

--- a/internal/handlers/dual/main.go
+++ b/internal/handlers/dual/main.go
@@ -67,6 +67,8 @@ func renderDualModePage(app *pocketbase.PocketBase, c *core.RequestEvent) error 
 	contentDto.Right = rightPane.Content
 	contentDto.LeftLinksOpenInOtherPane = leftPane.RenderTo == reverseSide(leftPane.Side)
 	contentDto.RightLinksOpenInOtherPane = rightPane.RenderTo == reverseSide(rightPane.Side)
+	contentDto.ArtworkSearchLeftUrl = buildDualArtworkSearchURL(leftPane, rightPane, "left")
+	contentDto.ArtworkSearchRightUrl = buildDualArtworkSearchURL(leftPane, rightPane, "right")
 	contentDto.CopyLeftToRightUrl = buildDualModeActionURL(leftPane, rightPane, "copy-left-to-right")
 	contentDto.CopyRightToLeftUrl = buildDualModeActionURL(leftPane, rightPane, "copy-right-to-left")
 	contentDto.ReverseUrl = buildDualModeActionURL(leftPane, rightPane, "reverse")
@@ -319,6 +321,20 @@ func buildDualModeActionURL(leftPane renderPaneDto, rightPane renderPaneDto, act
 	}
 
 	return buildDualModeURL(leftPath, rightPath, leftPane.RenderTo, rightPane.RenderTo)
+}
+
+func buildDualArtworkSearchURL(leftPane renderPaneDto, rightPane renderPaneDto, target string) string {
+	searchURL := url.GenerateDualModeUrl()
+	searchURL.Path = "/artworks"
+	queryValues := searchURL.Query()
+	queryValues.Set("dual_left", leftPane.RelPath)
+	queryValues.Set("dual_right", rightPane.RelPath)
+	queryValues.Set("dual_left_render_to", leftPane.RenderTo)
+	queryValues.Set("dual_right_render_to", rightPane.RenderTo)
+	queryValues.Set("dual_target", target)
+	searchURL.RawQuery = queryValues.Encode()
+
+	return searchURL.String()
 }
 
 func buildDualPaneLoadForms(leftPane renderPaneDto, rightPane renderPaneDto) dto.DualPaneLoadFormsDto {

--- a/internal/handlers/dual/main_test.go
+++ b/internal/handlers/dual/main_test.go
@@ -394,6 +394,28 @@ func TestBuildDualModeActionURL(t *testing.T) {
 	}
 }
 
+func TestBuildDualArtworkSearchURL(t *testing.T) {
+	left := renderPaneDto{RelPath: "/artists/left-123", RenderTo: "right"}
+	right := renderPaneDto{RelPath: "/artworks/right-456", RenderTo: "left"}
+
+	searchURL, err := url.Parse(buildDualArtworkSearchURL(left, right, "left"))
+	if err != nil {
+		t.Fatalf("expected valid search URL: %v", err)
+	}
+
+	if searchURL.Path != "/artworks" {
+		t.Fatalf("expected /artworks path, got %q", searchURL.Path)
+	}
+
+	assertDualModeQuery(t, searchURL, map[string]string{
+		"dual_left":            left.RelPath,
+		"dual_right":           right.RelPath,
+		"dual_left_render_to":  left.RenderTo,
+		"dual_right_render_to": right.RenderTo,
+		"dual_target":          "left",
+	})
+}
+
 func TestBuildDualPaneLoadForms(t *testing.T) {
 	left := renderPaneDto{RelPath: "/artists/left-123", RenderTo: "right"}
 	right := renderPaneDto{RelPath: "/artworks/right-456", RenderTo: "left"}

--- a/playwright-tests/dual-mode.spec.ts
+++ b/playwright-tests/dual-mode.spec.ts
@@ -106,6 +106,65 @@ test("loads an artwork through the chooser and preserves Dual Mode state", async
 	await expect(page.locator("#right h1")).toContainText("A Couple in a Tavern");
 });
 
+test("loads an artwork search result into the selected pane", async ({
+	page,
+}) => {
+	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+	await page.getByRole("link", { name: "Search left artworks" }).click();
+
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === "/artworks" &&
+			url.searchParams.get("dual_left") === aachenPath &&
+			url.searchParams.get("dual_right") === koedijckPath &&
+			url.searchParams.get("dual_target") === "left",
+	);
+
+	await page.getByLabel("Title").fill("A Couple in a Tavern");
+	const resultsResponse = page.waitForResponse(
+		(response) =>
+			response.url().includes("/artworks/results") &&
+			response.request().headers()["hx-request"] === "true",
+	);
+	await page.getByRole("button", { name: "Search" }).click();
+	await resultsResponse;
+
+	const clear = page.getByRole("link", { name: "Clear" });
+	await expect(clear).toHaveAttribute("href", /dual_target=left/);
+	const clearResponse = page.waitForResponse(
+		(response) =>
+			response.url().includes("/artworks?") &&
+			response.request().headers()["hx-request"] === "true",
+	);
+	await clear.click();
+	await clearResponse;
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === "/artworks" &&
+			url.searchParams.get("dual_left") === aachenPath &&
+			url.searchParams.get("dual_right") === koedijckPath &&
+			url.searchParams.get("dual_target") === "left",
+	);
+
+	await page.getByLabel("Title").fill("A Couple in a Tavern");
+	await page.getByRole("button", { name: "Search" }).click();
+
+	await page
+		.getByRole("link", {
+			name: "Open A Couple in a Tavern in left pane",
+		})
+		.click();
+
+	await expectDualModeState(
+		page,
+		aachenArtworkPath,
+		koedijckPath,
+		"left",
+		"right",
+	);
+	await expect(page.locator("#left h1")).toContainText("A Couple in a Tavern");
+});
+
 test("shows accessible lookup query states", async ({ page }) => {
 	await page.goto("/dual-mode");
 	await page.getByRole("button", { name: "Choose left" }).click();
@@ -413,5 +472,31 @@ test.describe("Dual Mode operations without JavaScript", () => {
 
 		await expectDualModeState(page, koedijckPath, koedijckPath);
 		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
+	});
+
+	test("loads an artwork search result through standard links", async ({
+		page,
+	}) => {
+		await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+		await page.getByRole("link", { name: "Search right artworks" }).click();
+
+		await page.getByLabel("Title").fill("A Couple in a Tavern");
+		await page.getByRole("button", { name: "Search" }).click();
+		await page
+			.getByRole("link", {
+				name: "Open A Couple in a Tavern in right pane",
+			})
+			.click();
+
+		await expectDualModeState(
+			page,
+			aachenPath,
+			aachenArtworkPath,
+			"left",
+			"right",
+		);
+		await expect(page.locator("#right h1")).toContainText(
+			"A Couple in a Tavern",
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- Add per-pane entry points to the full artwork search from Dual Mode.
- Preserve pane paths and link-target settings through search, clear, pagination, and result selection.
- Cover the canonical return URL, HTMX navigation, and no-JavaScript fallback; fix the existing staticcheck finding.

## Verification
- `go mod tidy && go vet ./... && go test ./... -cover`
- `mise run check`
- `bunx biome check playwright-tests/dual-mode.spec.ts`
- `bunx prettier --check docs/features/dual-mode-legacy-parity.md`
- `mise exec -- env WGA_PROTOCOL=http WGA_HOSTNAME=127.0.0.1:18092 bunx playwright test playwright-tests/dual-mode.spec.ts`

Closes #174.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added artwork search entry links in both panes for Dual Mode.
  * Dual Mode artwork results can open each item directly in the selected pane.
  * Dual Mode now preserves search filters, pagination, and Clear behavior across redirects.
* **Bug Fixes**
  * Corrected the artwork page title to display the artwork name.
* **Tests**
  * Added unit and end-to-end coverage for Dual Mode artwork search and pane-targeted result navigation (with and without JavaScript).
* **Documentation**
  * Updated the Legacy Dual-Window Parity checklist and acceptance criteria for Dual Mode artwork search readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->