### PR TITLE
feat: add browser-aware light and dark mode

### DIFF
--- a/internal/assets/templ/components/nav.templ
+++ b/internal/assets/templ/components/nav.templ
@@ -78,7 +78,10 @@ templ TopNav() {
 			</ul>
 		</div>
 		<div class="navbar-end">
-			// <a class="btn">Button</a>
+			<label class="flex cursor-pointer items-center gap-2 pr-3">
+				<span class="text-sm">Dark mode</span>
+				<input type="checkbox" class="toggle toggle-sm" aria-label="Dark mode" data-theme-toggle/>
+			</label>
 		</div>
 	</div>
 }

--- a/internal/assets/templ/layouts/layout.templ
+++ b/internal/assets/templ/layouts/layout.templ
@@ -42,6 +42,14 @@ templ LayoutBase(bodyClasses string, HtmxTargetArea string) {
 			if utils.GetCanonicalUrl(ctx) != "" {
 				<link rel="canonical" href={ utils.GetCanonicalUrl(ctx) }/>
 			}
+			<script>
+				try {
+					const savedTheme = window.localStorage.getItem("wga-theme");
+					if (savedTheme === "wga_light" || savedTheme === "wga_dark") {
+						document.documentElement.dataset.theme = savedTheme;
+					}
+				} catch {}
+			</script>
 			<link rel="stylesheet" href="/assets/css/style.css"/>
 			<link rel="stylesheet" href="/assets/css/vendor/viewer.min.css"/>
 			<link rel="apple-touch-icon" sizes="180x180" href="/assets/images/apple-touch-icon.png"/>

--- a/internal/assets/templ/pages/artist.templ
+++ b/internal/assets/templ/pages/artist.templ
@@ -25,7 +25,7 @@ templ ArtistBlock(a dto.Artist) {
 				<ol role="list" class="flex items-center space-x-4">
 					<li>
 						<div>
-							<a href="/" hx-get="/" class="text-gray-400 hover:text-gray-500">
+							<a href="/" hx-get="/" class="text-base-content/60 hover:text-base-content/80">
 								<svg class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 									<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd"></path>
 								</svg>
@@ -35,18 +35,18 @@ templ ArtistBlock(a dto.Artist) {
 					</li>
 					<li>
 						<div class="flex items-center">
-							<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+							<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 							</svg>
-							<a href="/artists" hx-get="/artists" hx-target={ a.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">Artists</a>
+							<a href="/artists" hx-get="/artists" hx-target={ a.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content">Artists</a>
 						</div>
 					</li>
 					<li>
 						<div class="flex items-center">
-							<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+							<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 							</svg>
-							<a href={ templ.URL(a.Url) } hx-get={ a.Url } hx-target={ a.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" aria-current="page">{ a.Name }</a>
+							<a href={ templ.URL(a.Url) } hx-get={ a.Url } hx-target={ a.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content" aria-current="page">{ a.Name }</a>
 						</div>
 					</li>
 				</ol>

--- a/internal/assets/templ/pages/artists.templ
+++ b/internal/assets/templ/pages/artists.templ
@@ -32,7 +32,7 @@ templ ArtistsPageBlock(c dto.ArtistsView) {
 			<ol role="list" class="flex items-center space-x-4">
 				<li>
 					<div>
-						<a href="/" hx-get="/" class="text-gray-400 hover:text-gray-500">
+						<a href="/" hx-get="/" class="text-base-content/60 hover:text-base-content/80">
 							<svg class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd"></path>
 							</svg>
@@ -42,10 +42,10 @@ templ ArtistsPageBlock(c dto.ArtistsView) {
 				</li>
 				<li>
 					<div class="flex items-center">
-						<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 							<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 						</svg>
-						<a href="/artists" hx-get="/artists" hx-target={ c.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" aria-current="page">Artists</a>
+						<a href="/artists" hx-get="/artists" hx-target={ c.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content" aria-current="page">Artists</a>
 					</div>
 				</li>
 			</ol>

--- a/internal/assets/templ/pages/artwork.templ
+++ b/internal/assets/templ/pages/artwork.templ
@@ -16,10 +16,10 @@ templ ArtworkPage(aw dto.Artwork) {
 templ ArtistListBreadcrumb(aw dto.Artwork) {
 	<li>
 		<div class="flex items-center">
-			<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+			<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 			</svg>
-			<a href="/artists" hx-get="/artists" hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">Artists</a>
+			<a href="/artists" hx-get="/artists" hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content">Artists</a>
 		</div>
 	</li>
 }
@@ -27,10 +27,10 @@ templ ArtistListBreadcrumb(aw dto.Artwork) {
 templ ArtworksBreadcrumb(aw dto.Artwork) {
 	<li>
 		<div class="flex items-center">
-			<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+			<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 			</svg>
-			<a href="/artworks" hx-get="/artworks" hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">Artworks</a>
+			<a href="/artworks" hx-get="/artworks" hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content">Artworks</a>
 		</div>
 	</li>
 }
@@ -38,10 +38,10 @@ templ ArtworksBreadcrumb(aw dto.Artwork) {
 templ ArtistBreadcrumbItem(aw dto.Artwork) {
 	<li>
 		<div class="flex items-center">
-			<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+			<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 				<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 			</svg>
-			<a href={ templ.URL(aw.Artist.Url) } hx-get={ aw.Artist.Url } hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">{ aw.Artist.Name }</a>
+			<a href={ templ.URL(aw.Artist.Url) } hx-get={ aw.Artist.Url } hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content">{ aw.Artist.Name }</a>
 		</div>
 	</li>
 }
@@ -57,7 +57,7 @@ templ ArtworkBlock(aw dto.Artwork) {
 					<ol role="list" class="flex items-center space-x-4">
 						<li>
 							<div>
-								<a href="/" hx-get="/" class="text-gray-400 hover:text-gray-500">
+								<a href="/" hx-get="/" class="text-base-content/60 hover:text-base-content/80">
 									<svg class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 										<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd"></path>
 									</svg>
@@ -73,10 +73,10 @@ templ ArtworkBlock(aw dto.Artwork) {
 						}
 						<li>
 							<div class="flex items-center">
-								<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+								<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 									<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 								</svg>
-								<a href={ templ.URL(aw.Url) } hx-get={ aw.Url } hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" aria-current="page">{ aw.Title }</a>
+								<a href={ templ.URL(aw.Url) } hx-get={ aw.Url } hx-target={ aw.HxTarget } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content" aria-current="page">{ aw.Title }</a>
 							</div>
 						</li>
 					</ol>

--- a/internal/assets/templ/pages/contributors.templ
+++ b/internal/assets/templ/pages/contributors.templ
@@ -44,7 +44,7 @@ templ Contributor(contributor GithubContributor) {
 		<p class="text-base leading-7 ">{ fmt.Sprintf("%d", contributor.Contributions) } commits</p>
 		<ul role="list" class="mt-6 flex gap-x-6">
 			<li>
-				<a class="has-sm-icon" href={ templ.SafeURL(contributor.HTMLURL) } rel="noopener" target="_blank" class="text-gray-400 hover:text-gray-500">
+				<a class="has-sm-icon" href={ templ.SafeURL(contributor.HTMLURL) } rel="noopener" target="_blank" class="text-base-content/60 hover:text-base-content/80">
 					<span class="sr-only">Github</span>
 					<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="currentColor" aria-hidden="true" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"></path></svg>
 				</a>
@@ -76,7 +76,7 @@ templ ContributorsBlock(c ContributorsPageDTO) {
 					<p class="text-base leading-7">TailwindUI Access</p>
 					<ul role="list" class="mt-6 flex gap-x-6">
 						<li>
-							<a class="has-sm-icon" href="https://zenosyne.tech" rel="noopener" target="_blank" class="text-gray-400 hover:text-gray-500">
+							<a class="has-sm-icon" href="https://zenosyne.tech" rel="noopener" target="_blank" class="text-base-content/60 hover:text-base-content/80">
 								<span class="sr-only">Homepage</span>
 								<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
 									<path stroke-linecap="round" stroke-linejoin="round" d="m20.893 13.393-1.135-1.135a2.252 2.252 0 0 1-.421-.585l-1.08-2.16a.414.414 0 0 0-.663-.107.827.827 0 0 1-.812.21l-1.273-.363a.89.89 0 0 0-.738 1.595l.587.39c.59.395.674 1.23.172 1.732l-.2.2c-.212.212-.33.498-.33.796v.41c0 .409-.11.809-.32 1.158l-1.315 2.191a2.11 2.11 0 0 1-1.81 1.025 1.055 1.055 0 0 1-1.055-1.055v-1.172c0-.92-.56-1.747-1.414-2.089l-.655-.261a2.25 2.25 0 0 1-1.383-2.46l.007-.042a2.25 2.25 0 0 1 .29-.787l.09-.15a2.25 2.25 0 0 1 2.37-1.048l1.178.236a1.125 1.125 0 0 0 1.302-.795l.208-.73a1.125 1.125 0 0 0-.578-1.315l-.665-.332-.091.091a2.25 2.25 0 0 1-1.591.659h-.18c-.249 0-.487.1-.662.274a.931.931 0 0 1-1.458-1.137l1.411-2.353a2.25 2.25 0 0 0 .286-.76m11.928 9.869A9 9 0 0 0 8.965 3.525m11.928 9.868A9 9 0 1 1 8.965 3.525"></path>
@@ -84,7 +84,7 @@ templ ContributorsBlock(c ContributorsPageDTO) {
 							</a>
 						</li>
 						<li>
-							<a class="has-sm-icon" href="https://www.linkedin.com/company/zenosyne/" rel="noopener" target="_blank" class="text-gray-400 hover:text-gray-500">
+							<a class="has-sm-icon" href="https://www.linkedin.com/company/zenosyne/" rel="noopener" target="_blank" class="text-base-content/60 hover:text-base-content/80">
 								<span class="sr-only">LinkedIn</span>
 								<svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
 									<path fill-rule="evenodd" d="M16.338 16.338H13.67V12.16c0-.995-.017-2.277-1.387-2.277-1.39 0-1.601 1.086-1.601 2.207v4.248H8.014v-8.59h2.559v1.174h.037c.356-.675 1.227-1.387 2.526-1.387 2.703 0 3.203 1.778 3.203 4.092v4.711zM5.005 6.575a1.548 1.548 0 11-.003-3.096 1.548 1.548 0 01.003 3.096zm-1.337 9.763H6.34v-8.59H3.667v8.59zM17.668 1H2.328C1.595 1 1 1.581 1 2.298v15.403C1 18.418 1.595 19 2.328 19h15.34c.734 0 1.332-.582 1.332-1.299V2.298C19 1.581 18.402 1 17.668 1z" clip-rule="evenodd"></path>

--- a/internal/assets/templ/pages/guestbook.templ
+++ b/internal/assets/templ/pages/guestbook.templ
@@ -26,7 +26,7 @@ templ GuestbookBlock(v GuestbookView) {
 			<ol role="list" class="flex items-center space-x-4">
 				<li>
 					<div>
-						<a href="/" hx-get="/" class="text-gray-400 hover:text-gray-500">
+						<a href="/" hx-get="/" class="text-base-content/60 hover:text-base-content/80">
 							<svg class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd"></path>
 							</svg>
@@ -36,18 +36,18 @@ templ GuestbookBlock(v GuestbookView) {
 				</li>
 				<li>
 					<div class="flex items-center">
-						<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 							<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 						</svg>
-						<a href="/guestbook" hx-get="/guestbook" class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700">Guestbook</a>
+						<a href="/guestbook" hx-get="/guestbook" class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content">Guestbook</a>
 					</div>
 				</li>
 				<li>
 					<div class="flex items-center">
-						<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 							<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 						</svg>
-						<a href={ templ.URL("/guestbook?year=" + v.SelectedYear) } hx-get={ "/guestbook?year=" + v.SelectedYear } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" aria-current="page">{ v.SelectedYear }</a>
+						<a href={ templ.URL("/guestbook?year=" + v.SelectedYear) } hx-get={ "/guestbook?year=" + v.SelectedYear } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content" aria-current="page">{ v.SelectedYear }</a>
 					</div>
 				</li>
 			</ol>

--- a/internal/assets/templ/pages/static.templ
+++ b/internal/assets/templ/pages/static.templ
@@ -26,7 +26,7 @@ templ StaticPageBlock(sp StaticPageDTO) {
 			<ol role="list" class="flex items-center space-x-4">
 				<li>
 					<div>
-						<a href="/" hx-get="/" class="text-gray-400 hover:text-gray-500">
+						<a href="/" hx-get="/" class="text-base-content/60 hover:text-base-content/80">
 							<svg class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 								<path fill-rule="evenodd" d="M9.293 2.293a1 1 0 011.414 0l7 7A1 1 0 0117 11h-1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-3a1 1 0 00-1-1H9a1 1 0 00-1 1v3a1 1 0 01-1 1H5a1 1 0 01-1-1v-6H3a1 1 0 01-.707-1.707l7-7z" clip-rule="evenodd"></path>
 							</svg>
@@ -36,10 +36,10 @@ templ StaticPageBlock(sp StaticPageDTO) {
 				</li>
 				<li>
 					<div class="flex items-center">
-						<svg class="h-5 w-5 flex-shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+						<svg class="h-5 w-5 flex-shrink-0 text-base-content/60" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
 							<path fill-rule="evenodd" d="M7.21 14.77a.75.75 0 01.02-1.06L11.168 10 7.23 6.29a.75.75 0 111.04-1.08l4.5 4.25a.75.75 0 010 1.08l-4.5 4.25a.75.75 0 01-1.06-.02z" clip-rule="evenodd"></path>
 						</svg>
-						<a href={ templ.URL(sp.Url) } hx-get={ sp.Url } class="ml-4 text-sm font-medium text-gray-500 hover:text-gray-700" aria-current="page">{ sp.Title }</a>
+						<a href={ templ.URL(sp.Url) } hx-get={ sp.Url } class="ml-4 text-sm font-medium text-base-content/70 hover:text-base-content" aria-current="page">{ sp.Title }</a>
 					</div>
 				</li>
 			</ol>

--- a/internal/utils/pagination.go
+++ b/internal/utils/pagination.go
@@ -191,14 +191,14 @@ func (p *Pagination) GetActivePageWrapper(text string) string {
 // It takes a `text` parameter representing the text to be displayed within the wrapper.
 // The method returns a string containing the disabled page wrapper HTML element.
 func (p *Pagination) GetDisabledPageWrapper(text string) string {
-	return "<a class=\"inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 cursor-not-allowed\">" + text + "</a>"
+	return "<a class=\"inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-base-content/60 cursor-not-allowed\">" + text + "</a>"
 }
 
 // GetAvailablePageWrapper returns a string representing a pagination link with the given href, page number, and htmxUrl.
 // If htmxTarget is specified, it adds the hx-target attribute to the link.
 func (p *Pagination) GetAvailablePageWrapper(href, page, htmxUrl string) string {
 
-	str := "<a class='inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 hover:border-secondary hover:text-secondary' aria-label='Goto page " + page + "' hx-get='" + htmxUrl + "' href='" + href
+	str := "<a class='inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-base-content/70 hover:border-secondary hover:text-secondary' aria-label='Goto page " + page + "' hx-get='" + htmxUrl + "' href='" + href
 
 	if p.htmxTarget != "" {
 		str = str + "' hx-target='#" + p.htmxTarget + "' hx-select='#" + p.htmxTarget + "' hx-swap='outerHTML"
@@ -211,7 +211,7 @@ func (p *Pagination) GetAvailablePageWrapper(href, page, htmxUrl string) string 
 
 // GetDots returns the HTML representation of the dots used for pagination ellipsis.
 func (p *Pagination) GetDots() string {
-	return "<span class=\"inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 cursor-not-allowed \">&hellip;</span>"
+	return "<span class=\"inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-base-content/60 cursor-not-allowed \">&hellip;</span>"
 }
 
 // GetPreviousButton returns the HTML string for the previous button in the pagination.

--- a/playwright-tests/theme.spec.ts
+++ b/playwright-tests/theme.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+for (const colorScheme of ["light", "dark"] as const) {
+	test(`uses the browser ${colorScheme} preference by default`, async ({
+		page,
+	}) => {
+		await page.emulateMedia({ colorScheme });
+		await page.goto("/");
+
+		await expect(page.locator("html")).toHaveCSS("color-scheme", colorScheme);
+
+		const themeToggle = page.getByRole("checkbox", { name: "Dark mode" });
+		if (colorScheme === "dark") {
+			await expect(themeToggle).toBeChecked();
+			return;
+		}
+
+		await expect(themeToggle).not.toBeChecked();
+	});
+}
+
+test("persists explicitly selected themes", async ({ page }) => {
+	await page.emulateMedia({ colorScheme: "dark" });
+	await page.goto("/");
+
+	const themeToggle = page.getByRole("checkbox", { name: "Dark mode" });
+	await expect(themeToggle).toBeChecked();
+	await themeToggle.focus();
+	await page.keyboard.press("Space");
+
+	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_light");
+	await expect(page.locator("html")).toHaveCSS("color-scheme", "light");
+
+	await page.reload();
+
+	await expect(themeToggle).not.toBeChecked();
+	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_light");
+
+	await themeToggle.focus();
+	await page.keyboard.press("Space");
+
+	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_dark");
+	await expect(page.locator("html")).toHaveCSS("color-scheme", "dark");
+
+	await page.reload();
+
+	await expect(themeToggle).toBeChecked();
+	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_dark");
+});
+
+test.describe("without JavaScript", () => {
+	test.use({ javaScriptEnabled: false });
+
+	test("uses the browser dark preference by default", async ({ page }) => {
+		await page.emulateMedia({ colorScheme: "dark" });
+		await page.goto("/");
+
+		await expect(page.locator("html")).toHaveCSS("color-scheme", "dark");
+	});
+});

--- a/playwright-tests/theme.spec.ts
+++ b/playwright-tests/theme.spec.ts
@@ -25,8 +25,7 @@ test("persists explicitly selected themes", async ({ page }) => {
 
 	const themeToggle = page.getByRole("checkbox", { name: "Dark mode" });
 	await expect(themeToggle).toBeChecked();
-	await themeToggle.focus();
-	await page.keyboard.press("Space");
+	await themeToggle.press("Space");
 
 	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_light");
 	await expect(page.locator("html")).toHaveCSS("color-scheme", "light");
@@ -36,8 +35,7 @@ test("persists explicitly selected themes", async ({ page }) => {
 	await expect(themeToggle).not.toBeChecked();
 	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_light");
 
-	await themeToggle.focus();
-	await page.keyboard.press("Space");
+	await themeToggle.press("Space");
 
 	await expect(page.locator("html")).toHaveAttribute("data-theme", "wga_dark");
 	await expect(page.locator("html")).toHaveCSS("color-scheme", "dark");

--- a/resources/css/style.pcss
+++ b/resources/css/style.pcss
@@ -43,6 +43,41 @@
   --noise: 0;
 }
 
+@plugin "daisyui/theme" {
+  name: "wga_dark";
+  default: false;
+  prefersdark: true;
+  color-scheme: "dark";
+  --color-base-100: oklch(20% 0.025 250);
+  --color-base-200: oklch(24% 0.025 250);
+  --color-base-300: oklch(29% 0.025 250);
+  --color-base-content: oklch(94% 0.01 250);
+  --color-primary: oklch(78% 0.1 250);
+  --color-primary-content: oklch(20% 0.025 250);
+  --color-secondary: oklch(78% 0.14 350);
+  --color-secondary-content: oklch(21% 0.03 350);
+  --color-accent: oklch(84% 0.14 100);
+  --color-accent-content: oklch(23% 0.04 100);
+  --color-neutral: oklch(30% 0.02 250);
+  --color-neutral-content: oklch(93% 0.01 250);
+  --color-info: oklch(75% 0.09 220);
+  --color-info-content: oklch(20% 0.02 220);
+  --color-success: oklch(76% 0.14 155);
+  --color-success-content: oklch(20% 0.03 155);
+  --color-warning: oklch(82% 0.15 85);
+  --color-warning-content: oklch(24% 0.04 85);
+  --color-error: oklch(74% 0.16 25);
+  --color-error-content: oklch(20% 0.03 25);
+  --radius-selector: 0.25rem;
+  --radius-field: 0.25rem;
+  --radius-box: 0.25rem;
+  --size-selector: 0.25rem;
+  --size-field: 0.25rem;
+  --border: 1px;
+  --depth: 0;
+  --noise: 0;
+}
+
 
 .btn.is-feedback {
   position: fixed;
@@ -59,35 +94,35 @@
 }
 
 .content {
-  @apply text-lg text-gray-950 leading-normal;
+  @apply text-lg text-base-content leading-normal;
   & > * + *,
   & li + li,
   & li > p + p {
     @apply mt-6;
   }
   & strong {
-    @apply text-black font-bold;
+    @apply text-base-content font-bold;
   }
   & a {
-    @apply text-black font-semibold;
+    @apply text-base-content font-semibold;
   }
   & strong a {
     @apply font-bold;
   }
   & h2 {
-    @apply leading-tight text-xl font-bold text-black mb-2 mt-10;
+    @apply leading-tight text-xl font-bold text-base-content mb-2 mt-10;
   }
   & h3 {
-    @apply leading-tight text-lg font-bold text-black mt-8 -mb-2;
+    @apply leading-tight text-lg font-bold text-base-content mt-8 -mb-2;
   }
   & code {
-    @apply font-mono text-sm inline bg-gray-400 px-1;
+    @apply font-mono text-sm inline bg-base-300 px-1;
   }
   & pre code {
-    @apply block bg-black p-4 rounded;
+    @apply block bg-neutral text-neutral-content p-4 rounded;
   }
   & blockquote {
-    @apply border-l-4 border-gray-300 pl-4 italic;
+    @apply border-l-4 border-base-300 pl-4 italic;
   }
   & ul,
   & ol {

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -142,6 +142,41 @@ interface ToastEvent extends Event {
 	};
 }
 
+const initThemeToggle = () => {
+	const themeToggle = document.querySelector<HTMLInputElement>(
+		"[data-theme-toggle]",
+	);
+	if (!themeToggle) {
+		return;
+	}
+
+	let savedTheme: string | null = null;
+	try {
+		savedTheme = window.localStorage.getItem("wga-theme");
+	} catch {}
+
+	const savedThemeIsValid =
+		savedTheme === "wga_light" || savedTheme === "wga_dark";
+	themeToggle.checked = savedTheme === "wga_dark";
+	if (!savedThemeIsValid) {
+		themeToggle.checked = window.matchMedia(
+			"(prefers-color-scheme: dark)",
+		).matches;
+	}
+
+	themeToggle.addEventListener("change", () => {
+		let theme = "wga_light";
+		if (themeToggle.checked) {
+			theme = "wga_dark";
+		}
+
+		document.documentElement.dataset.theme = theme;
+		try {
+			window.localStorage.setItem("wga-theme", theme);
+		} catch {}
+	});
+};
+
 const deepMerge = (target: object, source: object): object => {
 	// Iterate over keys in the source object
 	for (const key in source) {
@@ -841,6 +876,7 @@ const wgaInternal: wgaInternals = {
 
 (() => {
 	logger.debug("Initializing WGA");
+	initThemeToggle();
 	wgaInternal.func.init();
 })();
 


### PR DESCRIPTION
## Summary

- add a light/dark mode switch to the global navigation
- default the theme from the browser's `prefers-color-scheme` preference
- persist explicit selections and preserve them before first paint
- use semantic theme colours for dark-mode contrast
- add focused Playwright coverage

Closes #181

## Validation

- `bun run build`
- `templ generate`
- `go vet ./...`
- `go test ./...`
- `bunx playwright test playwright-tests/theme.spec.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dark mode toggle to the navigation bar.
  - Theme selection now follows browser preferences, persists across page reloads, and works without JavaScript.
  - Added a dedicated dark theme with improved colors for content, code blocks, links, and blockquotes.

- **Style**
  - Updated breadcrumbs, contributor links, and pagination controls to use theme-aware colors consistently.

- **Tests**
  - Added coverage for theme defaults, toggling, persistence, and no-JavaScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->