### PR TITLE
feat: cache guestbook year options

### DIFF
--- a/internal/assets/templ/pages/guestbook.templ
+++ b/internal/assets/templ/pages/guestbook.templ
@@ -67,18 +67,20 @@ templ GuestbookBlock(v GuestbookView) {
 					class="btn btn-primary"
 				>Add Entry</a>
 			</div>
-			<div>
-				<select
-					title="Select a year to filter the guestbook entries"
-					name="year"
-					hx-get="/guestbook"
-					class="select select-bordered w-full "
-				>
-					for _, year := range v.YearOptions {
-						<option value={ year } selected?={ v.SelectedYear == year }>{ year }</option>
-					}
-				</select>
-			</div>
+			if len(v.YearOptions) > 1 {
+				<div>
+					<select
+						title="Select a year to filter the guestbook entries"
+						name="year"
+						hx-get="/guestbook"
+						class="select select-bordered w-full "
+					>
+						for _, year := range v.YearOptions {
+							<option value={ year } selected?={ v.SelectedYear == year }>{ year }</option>
+						}
+					</select>
+				</div>
+			}
 		</div>
 		if len(v.Entries) > 0 {
 			@GuestbookEntries(v.Entries)

--- a/internal/assets/templ/pages/guestbook.templ
+++ b/internal/assets/templ/pages/guestbook.templ
@@ -10,6 +10,7 @@ import (
 
 type GuestbookView struct {
 	SelectedYear string
+	CurrentYear  string
 	YearOptions  []string
 	Entries      dto.GuestbookEntries
 }
@@ -85,7 +86,9 @@ templ GuestbookBlock(v GuestbookView) {
 			<div role="alert" class="alert alert-info">
 				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
 				<p>No entries found</p>
-				<p>Be the first to sign the guestbook for { v.SelectedYear }!</p>
+				if v.SelectedYear == v.CurrentYear {
+					<p>Be the first to sign the guestbook for { v.SelectedYear }!</p>
+				}
 			</div>
 		}
 	</section>

--- a/internal/assets/templ/pages/guestbook_test.go
+++ b/internal/assets/templ/pages/guestbook_test.go
@@ -47,3 +47,43 @@ func TestGuestbookBlockOnlyPromptsToSignForCurrentYear(t *testing.T) {
 		})
 	}
 }
+
+func TestGuestbookBlockOnlyShowsYearSelectorForMultipleYears(t *testing.T) {
+	tests := []struct {
+		name         string
+		yearOptions  []string
+		wantSelector bool
+	}{
+		{
+			name:         "no years",
+			wantSelector: false,
+		},
+		{
+			name:         "one year",
+			yearOptions:  []string{"2020"},
+			wantSelector: false,
+		},
+		{
+			name:         "multiple years",
+			yearOptions:  []string{"2026", "2020"},
+			wantSelector: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			content := GuestbookView{
+				YearOptions: tt.yearOptions,
+			}
+
+			if err := GuestbookBlock(content).Render(context.Background(), &output); err != nil {
+				t.Fatalf("render guestbook block: %v", err)
+			}
+
+			if got := strings.Contains(output.String(), `name="year"`); got != tt.wantSelector {
+				t.Errorf("year selector present = %t, want %t", got, tt.wantSelector)
+			}
+		})
+	}
+}

--- a/internal/assets/templ/pages/guestbook_test.go
+++ b/internal/assets/templ/pages/guestbook_test.go
@@ -1,0 +1,49 @@
+package pages
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestGuestbookBlockOnlyPromptsToSignForCurrentYear(t *testing.T) {
+	tests := []struct {
+		name         string
+		selectedYear string
+		currentYear  string
+		wantPrompt   bool
+	}{
+		{
+			name:         "current year",
+			selectedYear: "2026",
+			currentYear:  "2026",
+			wantPrompt:   true,
+		},
+		{
+			name:         "past year",
+			selectedYear: "2025",
+			currentYear:  "2026",
+			wantPrompt:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var output bytes.Buffer
+			content := GuestbookView{
+				SelectedYear: tt.selectedYear,
+				CurrentYear:  tt.currentYear,
+			}
+
+			if err := GuestbookBlock(content).Render(context.Background(), &output); err != nil {
+				t.Fatalf("render guestbook block: %v", err)
+			}
+
+			prompt := "Be the first to sign the guestbook for " + tt.selectedYear + "!"
+			if got := strings.Contains(output.String(), prompt); got != tt.wantPrompt {
+				t.Errorf("sign prompt present = %t, want %t", got, tt.wantPrompt)
+			}
+		})
+	}
+}

--- a/internal/constants/collections.go
+++ b/internal/constants/collections.go
@@ -11,5 +11,6 @@ const (
 	CollectionStaticPages = "static_pages"
 	CollectionStrings     = "strings"
 	CollectionSchools     = "schools"
-	CollectionGlossary   = "Glossary"
+	CollectionGlossary    = "Glossary"
+	CacheGuestbookYears   = "guestbook:years"
 )

--- a/internal/handlers/guestbook/main.go
+++ b/internal/handlers/guestbook/main.go
@@ -32,14 +32,33 @@ type GuestBookMessage struct {
 	HoneyPotEmail string `json:"honey_pot_email" form:"email" query:"honey_pot_email"`
 }
 
-func yearOptions() []string {
-	var years []string
+const guestbookYearsCacheTTL = 10 * time.Minute
 
-	for i := time.Now().Year(); i >= 1997; i-- {
-		years = append(years, fmt.Sprintf("%d", i))
+func yearOptions(app core.App) ([]string, error) {
+	if cached, ok := utils.GetCachedValue[[]string](app, constants.CacheGuestbookYears); ok {
+		return cached, nil
 	}
 
-	return years
+	entries, err := app.FindRecordsByFilter(constants.CollectionGuestbook, "", "-created", 0, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	years := []string{}
+	seen := map[string]struct{}{}
+	for _, entry := range entries {
+		year := fmt.Sprintf("%d", entry.GetDateTime("created").Time().Year())
+		if _, ok := seen[year]; ok {
+			continue
+		}
+
+		seen[year] = struct{}{}
+		years = append(years, year)
+	}
+
+	utils.SetCachedValue(app, constants.CacheGuestbookYears, years, guestbookYearsCacheTTL)
+
+	return years, nil
 }
 
 func convertRawEntriesToGuestbookEntries(entries []*core.Record) []dto.GuestbookEntry {
@@ -62,7 +81,13 @@ func EntriesHandler(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	app.Logger().Debug("Guestbook entries request received", "url", c.Request.URL)
 
 	fullUrl := url.GenerateCurrentPageUrl(c)
-	year := cmp.Or(c.Request.URL.Query().Get("year"), fmt.Sprintf("%d", time.Now().Year()))
+	currentYear := fmt.Sprintf("%d", time.Now().Year())
+	year := cmp.Or(c.Request.URL.Query().Get("year"), currentYear)
+	years, err := yearOptions(app)
+	if err != nil {
+		app.Logger().Error("Failed to get guestbook years", "error", err)
+		return utils.ServerFaultError(c)
+	}
 
 	app.Logger().Debug("Guestbook entries request", "year", year, "fullUrl", fullUrl)
 
@@ -78,7 +103,8 @@ func EntriesHandler(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 
 	content := pages.GuestbookView{
 		SelectedYear: year,
-		YearOptions:  yearOptions(),
+		CurrentYear:  currentYear,
+		YearOptions:  years,
 		Entries:      convertRawEntriesToGuestbookEntries(entries),
 	}
 

--- a/internal/handlers/guestbook/main.go
+++ b/internal/handlers/guestbook/main.go
@@ -34,9 +34,9 @@ type GuestBookMessage struct {
 
 const guestbookYearsCacheTTL = 10 * time.Minute
 
-func yearOptions(app core.App) ([]string, error) {
+func yearOptions(app core.App, currentYear string) ([]string, error) {
 	if cached, ok := utils.GetCachedValue[[]string](app, constants.CacheGuestbookYears); ok {
-		return cached, nil
+		return withCurrentYear(cached, currentYear), nil
 	}
 
 	entries, err := app.FindRecordsByFilter(constants.CollectionGuestbook, "", "-created", 0, 0)
@@ -58,7 +58,17 @@ func yearOptions(app core.App) ([]string, error) {
 
 	utils.SetCachedValue(app, constants.CacheGuestbookYears, years, guestbookYearsCacheTTL)
 
-	return years, nil
+	return withCurrentYear(years, currentYear), nil
+}
+
+func withCurrentYear(years []string, currentYear string) []string {
+	for _, year := range years {
+		if year == currentYear {
+			return years
+		}
+	}
+
+	return append([]string{currentYear}, years...)
 }
 
 func convertRawEntriesToGuestbookEntries(entries []*core.Record) []dto.GuestbookEntry {
@@ -84,7 +94,7 @@ func EntriesHandler(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	fullUrl := url.GenerateCurrentPageUrl(c)
 	currentYear := fmt.Sprintf("%d", time.Now().Year())
 	year := cmp.Or(c.Request.URL.Query().Get("year"), currentYear)
-	years, err := yearOptions(app)
+	years, err := yearOptions(app, currentYear)
 	if err != nil {
 		app.Logger().Error("Failed to get guestbook years", "error", err)
 		return utils.ServerFaultError(c)

--- a/internal/handlers/guestbook/main.go
+++ b/internal/handlers/guestbook/main.go
@@ -70,6 +70,7 @@ func convertRawEntriesToGuestbookEntries(entries []*core.Record) []dto.Guestbook
 			Email:    entry.GetString("email"),
 			Location: entry.GetString("location"),
 			Message:  entry.GetString("message"),
+			Created:  entry.GetDateTime("created").Time().Format("2006-01-02"),
 		})
 	}
 

--- a/internal/handlers/guestbook/main.go
+++ b/internal/handlers/guestbook/main.go
@@ -35,28 +35,29 @@ type GuestBookMessage struct {
 const guestbookYearsCacheTTL = 10 * time.Minute
 
 func yearOptions(app core.App, currentYear string) ([]string, error) {
-	if cached, ok := utils.GetCachedValue[[]string](app, constants.CacheGuestbookYears); ok {
-		return withCurrentYear(cached, currentYear), nil
-	}
+	years, err := utils.GetOrLoadCachedValue(app, constants.CacheGuestbookYears, guestbookYearsCacheTTL, func() ([]string, error) {
+		entries, err := app.FindRecordsByFilter(constants.CollectionGuestbook, "", "-created", 0, 0)
+		if err != nil {
+			return nil, err
+		}
 
-	entries, err := app.FindRecordsByFilter(constants.CollectionGuestbook, "", "-created", 0, 0)
+		years := []string{}
+		seen := map[string]struct{}{}
+		for _, entry := range entries {
+			year := fmt.Sprintf("%d", entry.GetDateTime("created").Time().Year())
+			if _, ok := seen[year]; ok {
+				continue
+			}
+
+			seen[year] = struct{}{}
+			years = append(years, year)
+		}
+
+		return years, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	years := []string{}
-	seen := map[string]struct{}{}
-	for _, entry := range entries {
-		year := fmt.Sprintf("%d", entry.GetDateTime("created").Time().Year())
-		if _, ok := seen[year]; ok {
-			continue
-		}
-
-		seen[year] = struct{}{}
-		years = append(years, year)
-	}
-
-	utils.SetCachedValue(app, constants.CacheGuestbookYears, years, guestbookYearsCacheTTL)
 
 	return withCurrentYear(years, currentYear), nil
 }

--- a/internal/handlers/guestbook/main_test.go
+++ b/internal/handlers/guestbook/main_test.go
@@ -10,47 +10,47 @@ import (
 	"github.com/pocketbase/pocketbase/tests"
 )
 
-func TestYearOptionsAreDerivedDistinctAndDescending(t *testing.T) {
+func TestYearOptionsIncludeCurrentYearWithDerivedYears(t *testing.T) {
 	app := newGuestbookTestApp(t)
 
 	saveGuestbookEntry(t, app, "2023-01-01 00:00:00.000Z")
 	saveGuestbookEntry(t, app, "2025-01-01 00:00:00.000Z")
 	saveGuestbookEntry(t, app, "2023-06-01 00:00:00.000Z")
 
-	assertYearOptions(t, app, []string{"2025", "2023"})
+	assertYearOptions(t, app, []string{"2026", "2025", "2023"})
 }
 
-func TestYearOptionsAreEmptyWithoutEntries(t *testing.T) {
+func TestYearOptionsIncludeCurrentYearWithoutEntries(t *testing.T) {
 	app := newGuestbookTestApp(t)
 
-	assertYearOptions(t, app, []string{})
+	assertYearOptions(t, app, []string{"2026"})
 }
 
 func TestYearOptionsRefreshAfterRecordChanges(t *testing.T) {
 	app := newGuestbookTestApp(t)
 
 	saveGuestbookEntry(t, app, "2025-01-01 00:00:00.000Z")
-	assertYearOptions(t, app, []string{"2025"})
+	assertYearOptions(t, app, []string{"2026", "2025"})
 
 	entry := saveGuestbookEntry(t, app, "2023-01-01 00:00:00.000Z")
-	assertYearOptions(t, app, []string{"2025", "2023"})
+	assertYearOptions(t, app, []string{"2026", "2025", "2023"})
 
 	entry.Set("created", "2022-01-01 00:00:00.000Z")
 	if err := app.Save(entry); err != nil {
 		t.Fatalf("update guestbook entry: %v", err)
 	}
-	assertYearOptions(t, app, []string{"2025", "2022"})
+	assertYearOptions(t, app, []string{"2026", "2025", "2022"})
 
 	if err := app.Delete(entry); err != nil {
 		t.Fatalf("delete guestbook entry: %v", err)
 	}
-	assertYearOptions(t, app, []string{"2025"})
+	assertYearOptions(t, app, []string{"2026", "2025"})
 }
 
 func newGuestbookTestApp(t *testing.T) *tests.TestApp {
 	t.Helper()
 
-	app, err := tests.NewTestApp()
+	app, err := tests.NewTestApp(t.TempDir())
 	if err != nil {
 		t.Fatalf("create test app: %v", err)
 	}
@@ -89,7 +89,7 @@ func saveGuestbookEntry(t *testing.T, app core.App, created string) *core.Record
 func assertYearOptions(t *testing.T, app core.App, want []string) {
 	t.Helper()
 
-	got, err := yearOptions(app)
+	got, err := yearOptions(app, "2026")
 	if err != nil {
 		t.Fatalf("get year options: %v", err)
 	}

--- a/internal/handlers/guestbook/main_test.go
+++ b/internal/handlers/guestbook/main_test.go
@@ -1,0 +1,100 @@
+package guestbook
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/hooks"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func TestYearOptionsAreDerivedDistinctAndDescending(t *testing.T) {
+	app := newGuestbookTestApp(t)
+
+	saveGuestbookEntry(t, app, "2023-01-01 00:00:00.000Z")
+	saveGuestbookEntry(t, app, "2025-01-01 00:00:00.000Z")
+	saveGuestbookEntry(t, app, "2023-06-01 00:00:00.000Z")
+
+	assertYearOptions(t, app, []string{"2025", "2023"})
+}
+
+func TestYearOptionsAreEmptyWithoutEntries(t *testing.T) {
+	app := newGuestbookTestApp(t)
+
+	assertYearOptions(t, app, []string{})
+}
+
+func TestYearOptionsRefreshAfterRecordChanges(t *testing.T) {
+	app := newGuestbookTestApp(t)
+
+	saveGuestbookEntry(t, app, "2025-01-01 00:00:00.000Z")
+	assertYearOptions(t, app, []string{"2025"})
+
+	entry := saveGuestbookEntry(t, app, "2023-01-01 00:00:00.000Z")
+	assertYearOptions(t, app, []string{"2025", "2023"})
+
+	entry.Set("created", "2022-01-01 00:00:00.000Z")
+	if err := app.Save(entry); err != nil {
+		t.Fatalf("update guestbook entry: %v", err)
+	}
+	assertYearOptions(t, app, []string{"2025", "2022"})
+
+	if err := app.Delete(entry); err != nil {
+		t.Fatalf("delete guestbook entry: %v", err)
+	}
+	assertYearOptions(t, app, []string{"2025"})
+}
+
+func newGuestbookTestApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	collection := core.NewBaseCollection(constants.CollectionGuestbook)
+	collection.Fields.Add(
+		&core.TextField{Name: "created"},
+	)
+	if err := app.Save(collection); err != nil {
+		t.Fatalf("create guestbook collection: %v", err)
+	}
+
+	hooks.RegisterHooks(app)
+
+	return app
+}
+
+func saveGuestbookEntry(t *testing.T, app core.App, created string) *core.Record {
+	t.Helper()
+
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionGuestbook)
+	if err != nil {
+		t.Fatalf("find guestbook collection: %v", err)
+	}
+
+	entry := core.NewRecord(collection)
+	entry.Set("created", created)
+	if err := app.Save(entry); err != nil {
+		t.Fatalf("create guestbook entry: %v", err)
+	}
+
+	return entry
+}
+
+func assertYearOptions(t *testing.T, app core.App, want []string) {
+	t.Helper()
+
+	got, err := yearOptions(app)
+	if err != nil {
+		t.Fatalf("get year options: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("year options = %v, want %v", got, want)
+	}
+}

--- a/internal/hooks/files.go
+++ b/internal/hooks/files.go
@@ -1,11 +1,10 @@
 package hooks
 
 import (
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func fileDownloadHook(app *pocketbase.PocketBase) {
+func fileDownloadHook(app core.App) {
 	app.Logger().Debug("Registering file download hook...")
 	app.OnFileDownloadRequest().BindFunc(func(e *core.FileDownloadRequestEvent) error {
 		// e.App

--- a/internal/hooks/guestbook.go
+++ b/internal/hooks/guestbook.go
@@ -1,0 +1,18 @@
+package hooks
+
+import (
+	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/utils"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func guestbookYearsCacheHook(app core.App) {
+	invalidate := func(e *core.RecordEvent) error {
+		utils.DeleteCachedValue(e.App, constants.CacheGuestbookYears)
+		return e.Next()
+	}
+
+	app.OnRecordAfterCreateSuccess(constants.CollectionGuestbook).BindFunc(invalidate)
+	app.OnRecordAfterUpdateSuccess(constants.CollectionGuestbook).BindFunc(invalidate)
+	app.OnRecordAfterDeleteSuccess(constants.CollectionGuestbook).BindFunc(invalidate)
+}

--- a/internal/hooks/main.go
+++ b/internal/hooks/main.go
@@ -1,8 +1,9 @@
 package hooks
 
-import "github.com/pocketbase/pocketbase"
+import "github.com/pocketbase/pocketbase/core"
 
-func RegisterHooks(app *pocketbase.PocketBase) {
+func RegisterHooks(app core.App) {
 	app.Logger().Debug("Registering hooks...")
 	fileDownloadHook(app)
+	guestbookYearsCacheHook(app)
 }

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -1,15 +1,34 @@
 package utils
 
 import (
+	"sync"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
 )
 
-const cacheExpirySuffix = ":meta:expires_unix_nano"
+const (
+	cacheExpirySuffix = ":meta:expires_unix_nano"
+	cacheStateSuffix  = ":meta:state"
+)
+
+type cachedValueState struct {
+	mu         sync.Mutex
+	generation uint64
+}
 
 func cacheExpiryKey(key string) string {
 	return key + cacheExpirySuffix
+}
+
+func cacheStateKey(key string) string {
+	return key + cacheStateSuffix
+}
+
+func cachedValueStateFor(app core.App, key string) *cachedValueState {
+	return app.Store().GetOrSet(cacheStateKey(key), func() any {
+		return &cachedValueState{}
+	}).(*cachedValueState)
 }
 
 func SetCachedValue(app core.App, key string, value any, ttl time.Duration) {
@@ -46,7 +65,39 @@ func GetCachedValue[T any](app core.App, key string) (T, bool) {
 	return typedValue, true
 }
 
+func GetOrLoadCachedValue[T any](app core.App, key string, ttl time.Duration, load func() (T, error)) (T, error) {
+	var zero T
+	state := cachedValueStateFor(app, key)
+
+	state.mu.Lock()
+	if cached, ok := GetCachedValue[T](app, key); ok {
+		state.mu.Unlock()
+		return cached, nil
+	}
+	generation := state.generation
+	state.mu.Unlock()
+
+	value, err := load()
+	if err != nil {
+		return zero, err
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	if generation == state.generation {
+		SetCachedValue(app, key, value, ttl)
+	}
+
+	return value, nil
+}
+
 func DeleteCachedValue(app core.App, key string) {
+	state := cachedValueStateFor(app, key)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	state.generation++
 	app.Store().Remove(key)
 	app.Store().Remove(cacheExpiryKey(key))
 }

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"time"
 
-	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
 )
 
 const cacheExpirySuffix = ":meta:expires_unix_nano"
@@ -12,7 +12,7 @@ func cacheExpiryKey(key string) string {
 	return key + cacheExpirySuffix
 }
 
-func SetCachedValue(app *pocketbase.PocketBase, key string, value any, ttl time.Duration) {
+func SetCachedValue(app core.App, key string, value any, ttl time.Duration) {
 	app.Store().Set(key, value)
 
 	if ttl <= 0 {
@@ -23,7 +23,7 @@ func SetCachedValue(app *pocketbase.PocketBase, key string, value any, ttl time.
 	app.Store().Set(cacheExpiryKey(key), time.Now().Add(ttl).UnixNano())
 }
 
-func GetCachedValue[T any](app *pocketbase.PocketBase, key string) (T, bool) {
+func GetCachedValue[T any](app core.App, key string) (T, bool) {
 	var zero T
 
 	if !app.Store().Has(key) {
@@ -44,4 +44,9 @@ func GetCachedValue[T any](app *pocketbase.PocketBase, key string) (T, bool) {
 	}
 
 	return typedValue, true
+}
+
+func DeleteCachedValue(app core.App, key string) {
+	app.Store().Remove(key)
+	app.Store().Remove(cacheExpiryKey(key))
 }

--- a/internal/utils/cache_test.go
+++ b/internal/utils/cache_test.go
@@ -60,3 +60,62 @@ func TestDeleteCachedValueRemovesValueAndExpiry(t *testing.T) {
 		t.Fatalf("expected cache expiry to be removed")
 	}
 }
+
+func TestGetOrLoadCachedValueCachesLoadedValue(t *testing.T) {
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+	key := "cache:test:load"
+
+	value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+		return "hello", nil
+	})
+	if err != nil {
+		t.Fatalf("load cached value: %v", err)
+	}
+
+	if value != "hello" {
+		t.Fatalf("expected loaded value 'hello', got %q", value)
+	}
+
+	cached, ok := GetCachedValue[string](app, key)
+	if !ok || cached != "hello" {
+		t.Fatalf("expected loaded value to be cached, got %q", cached)
+	}
+}
+
+func TestGetOrLoadCachedValueDoesNotRestoreInvalidatedValue(t *testing.T) {
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+	key := "cache:test:invalidation-race"
+	started := make(chan struct{})
+	release := make(chan struct{})
+	type result struct {
+		value string
+		err   error
+	}
+	results := make(chan result, 1)
+
+	go func() {
+		value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+			close(started)
+			<-release
+			return "stale", nil
+		})
+		results <- result{value: value, err: err}
+	}()
+
+	<-started
+	DeleteCachedValue(app, key)
+	close(release)
+
+	loaded := <-results
+	if loaded.err != nil {
+		t.Fatalf("load cached value: %v", loaded.err)
+	}
+
+	if loaded.value != "stale" {
+		t.Fatalf("expected in-flight result 'stale', got %q", loaded.value)
+	}
+
+	if _, ok := GetCachedValue[string](app, key); ok {
+		t.Fatalf("expected invalidated value to remain absent")
+	}
+}

--- a/internal/utils/cache_test.go
+++ b/internal/utils/cache_test.go
@@ -44,3 +44,19 @@ func TestGetCachedValueRespectsExpiry(t *testing.T) {
 		t.Fatalf("expected cached value to be expired")
 	}
 }
+
+func TestDeleteCachedValueRemovesValueAndExpiry(t *testing.T) {
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+	key := "cache:test:delete"
+
+	SetCachedValue(app, key, "hello", time.Hour)
+	DeleteCachedValue(app, key)
+
+	if app.Store().Has(key) {
+		t.Fatalf("expected cached value to be removed")
+	}
+
+	if app.Store().Has(cacheExpiryKey(key)) {
+		t.Fatalf("expected cache expiry to be removed")
+	}
+}

--- a/playwright-tests/artists.spec.ts
+++ b/playwright-tests/artists.spec.ts
@@ -6,21 +6,21 @@ test("check artists page", async ({ page }) => {
   // Click the get started link.
   await page.getByRole("link", { name: "Artists", exact: true }).click();
 
-  // expect to find "AACHEN, Hans von" on the page, in a table.
+  // expect to find "Synthetic Artist 01" on the page, in a table.
 
-  await expect(page.locator("table")).toHaveText(/AACHEN, Hans von/);
+  await expect(page.locator("table")).toHaveText(/Synthetic Artist 01/);
 
-  // use the search box to find "KOEDIJCK"
+  // use the search box to find "Synthetic Artist 02"
   await page
     .getByPlaceholder("Find an artist")
-    .pressSequentially("KOEDIJCK", { delay: 100 });
+    .pressSequentially("Synthetic Artist 02", { delay: 100 });
 
-  // expect to find "KOEDIJCK, Isaack" on the page, in a table.
-  await expect(page.locator("table")).toHaveText(/KOEDIJCK, Isaack/);
+  // expect to find "Synthetic Artist 02" on the page, in a table.
+  await expect(page.locator("table")).toHaveText(/Synthetic Artist 02/);
 
-  // follow the link KOEDIJCK, Isaack
-  await page.getByRole("link", { name: "KOEDIJCK, Isaack" }).click();
+  // follow the link Synthetic Artist 02
+  await page.getByRole("link", { name: "Synthetic Artist 02" }).click();
 
-  // expect to find "KOEDIJCK, Isaack" in the title.
-  await expect(page).toHaveTitle(/KOEDIJCK, Isaack/);
+  // expect to find "Synthetic Artist 02" in the title.
+  await expect(page).toHaveTitle(/Synthetic Artist 02/);
 });

--- a/playwright-tests/artwork-search.spec.ts
+++ b/playwright-tests/artwork-search.spec.ts
@@ -12,61 +12,61 @@ async function expectArtworkResults(page) {
 test("artwork search", async ({ page }) => {
   await page.goto("/artworks");
   await expect(page.locator("h1")).toHaveText(/Artwork search/);
-  await page.locator("[name='title']").fill("Allegory");
+  await page.locator("[name='title']").fill("Synthetic Artwork 01-01");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
   await expect(page.locator("#search-result-container")).toContainText(
-    /artworks found\./i,
+    "1 artwork found.",
   );
 });
 
 test("artform search", async ({ page }) => {
   await page.goto("/artworks");
-  await page.locator("[name='art_form']").selectOption("painting");
+  await page.locator("[name='art_form']").selectOption("synthetic-test-form");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("art type search", async ({ page }) => {
   await page.goto("/artworks");
-  await page.locator("[name='art_type']").selectOption("mythological");
+  await page.locator("[name='art_type']").selectOption("synthetic-test-type");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("art school search", async ({ page }) => {
   await page.goto("/artworks");
-  await page.locator("[name='art_school']").selectOption("hungarian");
+  await page.locator("[name='art_school']").selectOption("synthetic-test-school");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("art type and school combined search", async ({ page }) => {
   await page.goto("/artworks");
-  await page.locator("[name='art_type']").selectOption("mythological");
-  await page.locator("[name='art_school']").selectOption("hungarian");
+  await page.locator("[name='art_type']").selectOption("synthetic-test-type");
+  await page.locator("[name='art_school']").selectOption("synthetic-test-school");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("title search", async ({ page }) => {
   await page.goto("http://localhost:8090/artworks");
-  await page.locator("[name='title']").fill("Allegory");
+  await page.locator("[name='title']").fill("Synthetic Artwork 01-01");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("artist name search", async ({ page }) => {
   await page.goto("http://localhost:8090/artworks");
-  await page.locator("[name='artist']").fill("aachen");
+  await page.locator("[name='artist']").fill("Synthetic Artist 01");
   await page.getByRole("button", { name: "Search" }).click();
   await expectArtworkResults(page);
 });
 
 test("clear resets the artwork search form", async ({ page }) => {
   await page.goto("http://localhost:8090/artworks");
-  await page.locator("[name='title']").fill("Allegory");
-  await page.locator("[name='art_school']").selectOption("hungarian");
+  await page.locator("[name='title']").fill("Synthetic Artwork 01-01");
+  await page.locator("[name='art_school']").selectOption("synthetic-test-school");
   await page.getByRole("link", { name: "Clear" }).click();
 
   await expect(page).toHaveURL(/\/artworks$/);

--- a/playwright-tests/dual-mode.spec.ts
+++ b/playwright-tests/dual-mode.spec.ts
@@ -1,9 +1,9 @@
 import { type Route, expect, test } from "@playwright/test";
 
-const aachenPath = "/artists/aachen-hans-von-139ac2dff50d65c";
-const aachenArtworkPath =
-	"/artists/aachen-hans-von-139ac2dff50d65c/a-couple-in-a-tavern-4035847eedfacc4";
-const koedijckPath = "/artists/koedijck-isaack-3ed9e200b9e8252";
+const artistOnePath = "/artists/synthetic-artist-01-ad32608c6e36b2e";
+const artistOneArtworkPath =
+	"/artists/synthetic-artist-01-ad32608c6e36b2e/synthetic-artwork-01-01-2225c982be1af02";
+const artistTwoPath = "/artists/synthetic-artist-02-2236bdd57f7492e";
 
 const dualModeURL = (
 	left: string,
@@ -55,14 +55,14 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 	const lookupResponse = page.waitForResponse((response) =>
 		response.url().includes("/dual-mode/lookup"),
 	);
-	await page.getByLabel("Search collection").fill("AACHEN");
+	await page.getByLabel("Search collection").fill("Synthetic Artist 01");
 	await lookupResponse;
 	await page
-		.getByRole("button", { name: "AACHEN, Hans von", exact: true })
+		.getByRole("button", { name: "Synthetic Artist 01", exact: true })
 		.click();
 
 	await expect(page).toHaveURL(/\/dual-mode\?.*left=/);
-	await expect(page.locator("#left h1")).toContainText("AACHEN, Hans von");
+	await expect(page.locator("#left h1")).toContainText("Synthetic Artist 01");
 
 	await page
 		.locator("#left")
@@ -71,7 +71,7 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 		.click();
 
 	await expect(page.locator("#dual-area")).toHaveCount(1);
-	await expect(page.locator("#left h1")).toContainText("AACHEN, Hans von");
+	await expect(page.locator("#left h1")).toContainText("Synthetic Artist 01");
 	await expect(page.locator("#right")).not.toContainText(
 		"Choose content for comparison",
 	);
@@ -80,47 +80,49 @@ test("loads an artist through the chooser and opens its artwork in the other pan
 test("loads an artwork through the chooser and preserves Dual Mode state", async ({
 	page,
 }) => {
-	await page.goto(dualModeURL(aachenPath, "default", "left", "right"));
+	await page.goto(dualModeURL(artistOnePath, "default", "left", "right"));
 	await page.getByRole("button", { name: "Choose right" }).click();
 	await page.getByLabel("Search for").selectOption("artwork");
 
 	const lookupResponse = page.waitForResponse((response) =>
 		response.url().includes("/dual-mode/lookup"),
 	);
-	await page.getByLabel("Search collection").fill("A Couple");
+	await page.getByLabel("Search collection").fill("Synthetic Artwork");
 	await lookupResponse;
 
 	const artworkResult = page.getByRole("button", {
-		name: /A Couple in a Tavern/,
+		name: /Synthetic Artwork 01-01/,
 	});
-	await expect(artworkResult).toContainText("AACHEN, Hans von");
+	await expect(artworkResult).toContainText("Synthetic Artist 01");
 	await artworkResult.click();
 
 	await expectDualModeState(
 		page,
-		aachenPath,
-		aachenArtworkPath,
+		artistOnePath,
+		artistOneArtworkPath,
 		"left",
 		"right",
 	);
-	await expect(page.locator("#right h1")).toContainText("A Couple in a Tavern");
+	await expect(page.locator("#right h1")).toContainText(
+		"Synthetic Artwork 01-01",
+	);
 });
 
 test("loads an artwork search result into the selected pane", async ({
 	page,
 }) => {
-	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath, "left", "right"));
 	await page.getByRole("link", { name: "Search left artworks" }).click();
 
 	await expect(page).toHaveURL(
 		(url) =>
 			url.pathname === "/artworks" &&
-			url.searchParams.get("dual_left") === aachenPath &&
-			url.searchParams.get("dual_right") === koedijckPath &&
+			url.searchParams.get("dual_left") === artistOnePath &&
+			url.searchParams.get("dual_right") === artistTwoPath &&
 			url.searchParams.get("dual_target") === "left",
 	);
 
-	await page.getByLabel("Title").fill("A Couple in a Tavern");
+	await page.getByLabel("Title").fill("Synthetic Artwork 01-01");
 	const resultsResponse = page.waitForResponse(
 		(response) =>
 			response.url().includes("/artworks/results") &&
@@ -141,28 +143,30 @@ test("loads an artwork search result into the selected pane", async ({
 	await expect(page).toHaveURL(
 		(url) =>
 			url.pathname === "/artworks" &&
-			url.searchParams.get("dual_left") === aachenPath &&
-			url.searchParams.get("dual_right") === koedijckPath &&
+			url.searchParams.get("dual_left") === artistOnePath &&
+			url.searchParams.get("dual_right") === artistTwoPath &&
 			url.searchParams.get("dual_target") === "left",
 	);
 
-	await page.getByLabel("Title").fill("A Couple in a Tavern");
+	await page.getByLabel("Title").fill("Synthetic Artwork 01-01");
 	await page.getByRole("button", { name: "Search" }).click();
 
 	await page
 		.getByRole("link", {
-			name: "Open A Couple in a Tavern in left pane",
+			name: "Open Synthetic Artwork 01-01 in left pane",
 		})
 		.click();
 
 	await expectDualModeState(
 		page,
-		aachenArtworkPath,
-		koedijckPath,
+		artistOneArtworkPath,
+		artistTwoPath,
 		"left",
 		"right",
 	);
-	await expect(page.locator("#left h1")).toContainText("A Couple in a Tavern");
+	await expect(page.locator("#left h1")).toContainText(
+		"Synthetic Artwork 01-01",
+	);
 });
 
 test("shows accessible lookup query states", async ({ page }) => {
@@ -201,7 +205,7 @@ test("cancels an active lookup when the chooser closes", async ({ page }) => {
 	const lookupRequest = page.waitForRequest((request) =>
 		request.url().includes("/dual-mode/lookup"),
 	);
-	await page.getByLabel("Search collection").fill("AACHEN");
+	await page.getByLabel("Search collection").fill("Synthetic Artist 01");
 	await lookupRequest;
 	await expect.poll(() => delayedRoute).not.toBeNull();
 	await page.keyboard.press("Escape");
@@ -222,7 +226,7 @@ test("cancels an active lookup when the chooser closes", async ({ page }) => {
 });
 
 test("persists a same-pane target choice", async ({ page }) => {
-	await page.goto(`/dual-mode?left=${aachenPath}&right=default`);
+	await page.goto(`/dual-mode?left=${artistOnePath}&right=default`);
 
 	const leftTargets = paneTargetControls(page, "left");
 	await expect(
@@ -253,13 +257,13 @@ test("keeps a valid pane when the other selected record is missing", async ({
 	page,
 }) => {
 	await page.goto(
-		`/dual-mode?left=/artists/missing-000000000000000&right=${aachenPath}`,
+		`/dual-mode?left=/artists/missing-000000000000000&right=${artistOnePath}`,
 	);
 
 	await expect(page.locator("#left")).toContainText(
 		"Choose content for comparison",
 	);
-	await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	await expect(page.locator("#right h1")).toContainText("Synthetic Artist 01");
 });
 
 test("shows the desktop-only message on a small screen", async ({ page }) => {
@@ -277,7 +281,7 @@ test("updates pane state through enhanced operation links", async ({
 }) => {
 	const operations = page.getByRole("navigation", { name: "Pane operations" });
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	const reverseResponse = page.waitForResponse(
 		(response) =>
 			response.url().includes("/dual-mode") &&
@@ -287,43 +291,43 @@ test("updates pane state through enhanced operation links", async ({
 		.getByRole("link", { name: "Reverse panes", exact: true })
 		.click();
 	await reverseResponse;
-	await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
-	await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
-	await expectDualModeState(page, koedijckPath, aachenPath);
+	await expect(page.locator("#left h1")).toContainText("Synthetic Artist 02");
+	await expect(page.locator("#right h1")).toContainText("Synthetic Artist 01");
+	await expectDualModeState(page, artistTwoPath, artistOnePath);
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await operations
 		.getByRole("link", { name: "Copy left to right", exact: true })
 		.click();
-	await expectDualModeState(page, aachenPath, aachenPath);
-	await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	await expectDualModeState(page, artistOnePath, artistOnePath);
+	await expect(page.locator("#right h1")).toContainText("Synthetic Artist 01");
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await operations
 		.getByRole("link", { name: "Copy right to left", exact: true })
 		.click();
-	await expectDualModeState(page, koedijckPath, koedijckPath);
-	await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
+	await expectDualModeState(page, artistTwoPath, artistTwoPath);
+	await expect(page.locator("#left h1")).toContainText("Synthetic Artist 02");
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await operations
 		.getByRole("link", { name: "Clear left", exact: true })
 		.click();
-	await expectDualModeState(page, "default", koedijckPath);
+	await expectDualModeState(page, "default", artistTwoPath);
 	await expect(page.locator("#left")).toContainText(
 		"Choose content for comparison",
 	);
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await operations
 		.getByRole("link", { name: "Clear right", exact: true })
 		.click();
-	await expectDualModeState(page, aachenPath, "default");
+	await expectDualModeState(page, artistOnePath, "default");
 	await expect(page.locator("#right")).toContainText(
 		"Choose content for comparison",
 	);
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await operations
 		.getByRole("link", { name: "Standard view", exact: true })
 		.click();
@@ -334,60 +338,68 @@ test("loads pane paths through enhanced forms", async ({ page }) => {
 	const leftForm = page.getByRole("form", { name: "Load left pane" });
 	const rightForm = page.getByRole("form", { name: "Load right pane" });
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await expect(leftForm.getByLabel("Load left pane path")).toHaveValue(
-		aachenPath,
+		artistOnePath,
 	);
 	const leftResponse = page.waitForResponse(
 		(response) =>
 			response.url().includes("/dual-mode") &&
 			response.request().headers()["hx-request"] === "true",
 	);
-	await leftForm.getByLabel("Load left pane path").fill(koedijckPath);
+	await leftForm.getByLabel("Load left pane path").fill(artistTwoPath);
 	await leftForm
 		.getByRole("button", { name: "Load left", exact: true })
 		.click();
 	await leftResponse;
-	await expectDualModeState(page, koedijckPath, koedijckPath);
-	await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
+	await expectDualModeState(page, artistTwoPath, artistTwoPath);
+	await expect(page.locator("#left h1")).toContainText("Synthetic Artist 02");
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
-	await rightForm.getByLabel("Load right pane path").fill(aachenPath);
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath, "left", "right"));
+	await rightForm.getByLabel("Load right pane path").fill(artistOnePath);
 	await rightForm
 		.getByRole("button", { name: "Load right", exact: true })
 		.click();
-	await expectDualModeState(page, aachenPath, aachenPath, "left", "right");
-	await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+	await expectDualModeState(
+		page,
+		artistOnePath,
+		artistOnePath,
+		"left",
+		"right",
+	);
+	await expect(page.locator("#right h1")).toContainText("Synthetic Artist 01");
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
-	await leftForm.getByLabel("Load left pane path").fill(aachenArtworkPath);
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath, "left", "right"));
+	await leftForm.getByLabel("Load left pane path").fill(artistOneArtworkPath);
 	await leftForm
 		.getByRole("button", { name: "Load left", exact: true })
 		.click();
 	await expectDualModeState(
 		page,
-		aachenArtworkPath,
-		koedijckPath,
+		artistOneArtworkPath,
+		artistTwoPath,
 		"left",
 		"right",
 	);
-	await expect(page.locator("#left h1")).toContainText("A Couple in a Tavern");
+	await expect(page.locator("#left h1")).toContainText(
+		"Synthetic Artwork 01-01",
+	);
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	await leftForm
 		.getByLabel("Load left pane path")
 		.fill("/pages/privacy-policy");
 	await leftForm
 		.getByRole("button", { name: "Load left", exact: true })
 		.click();
-	await expectDualModeState(page, "default", koedijckPath);
+	await expectDualModeState(page, "default", artistTwoPath);
 	await expect(page.locator("#left")).toContainText(
 		"Choose content for comparison",
 	);
 });
 
 test("updates pane targets through enhanced links", async ({ page }) => {
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	const leftTargets = paneTargetControls(page, "left");
 	const targetResponse = page.waitForResponse(
 		(response) =>
@@ -396,107 +408,137 @@ test("updates pane targets through enhanced links", async ({ page }) => {
 	);
 	await leftTargets.getByRole("link", { name: "This pane" }).click();
 	await targetResponse;
-	await expectDualModeState(page, aachenPath, koedijckPath, "left", "left");
+	await expectDualModeState(page, artistOnePath, artistTwoPath, "left", "left");
 	await expect(
 		leftTargets.getByRole("link", { name: "This pane" }),
 	).toHaveAttribute("aria-current", "true");
 
-	await page.goto(dualModeURL(aachenPath, koedijckPath));
+	await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 	const rightTargets = paneTargetControls(page, "right");
 	await rightTargets.getByRole("link", { name: "This pane" }).click();
-	await expectDualModeState(page, aachenPath, koedijckPath, "right", "right");
+	await expectDualModeState(
+		page,
+		artistOnePath,
+		artistTwoPath,
+		"right",
+		"right",
+	);
 
 	await rightTargets.getByRole("link", { name: "Other pane" }).click();
-	await expectDualModeState(page, aachenPath, koedijckPath, "right", "left");
+	await expectDualModeState(
+		page,
+		artistOnePath,
+		artistTwoPath,
+		"right",
+		"left",
+	);
 });
 
 test.describe("Dual Mode operations without JavaScript", () => {
 	test.use({ javaScriptEnabled: false });
 
 	test("falls back to the reverse-pane href", async ({ page }) => {
-		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 		await page
 			.getByRole("navigation", { name: "Pane operations" })
 			.getByRole("link", { name: "Reverse panes", exact: true })
 			.click();
 
-		await expectDualModeState(page, koedijckPath, aachenPath);
-		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
-		await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+		await expectDualModeState(page, artistTwoPath, artistOnePath);
+		await expect(page.locator("#left h1")).toContainText("Synthetic Artist 02");
+		await expect(page.locator("#right h1")).toContainText(
+			"Synthetic Artist 01",
+		);
 	});
 
 	test("changes pane targets through standard hrefs", async ({ page }) => {
-		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 		await paneTargetControls(page, "left")
 			.getByRole("link", { name: "This pane" })
 			.click();
-		await expectDualModeState(page, aachenPath, koedijckPath, "left", "left");
+		await expectDualModeState(
+			page,
+			artistOnePath,
+			artistTwoPath,
+			"left",
+			"left",
+		);
 
 		await page
 			.locator("#left")
 			.getByRole("link", { name: "Learn More" })
 			.first()
 			.click();
-		await expect(page.locator("#right h1")).toContainText("KOEDIJCK, Isaack");
+		await expect(page.locator("#right h1")).toContainText(
+			"Synthetic Artist 02",
+		);
 
-		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 		await paneTargetControls(page, "right")
 			.getByRole("link", { name: "This pane" })
 			.click();
-		await expectDualModeState(page, aachenPath, koedijckPath, "right", "right");
+		await expectDualModeState(
+			page,
+			artistOnePath,
+			artistTwoPath,
+			"right",
+			"right",
+		);
 	});
 
 	test("loads a right pane path through a standard GET form", async ({
 		page,
 	}) => {
-		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 		const rightForm = page.getByRole("form", { name: "Load right pane" });
-		await rightForm.getByLabel("Load right pane path").fill(aachenPath);
+		await rightForm.getByLabel("Load right pane path").fill(artistOnePath);
 		await rightForm
 			.getByRole("button", { name: "Load right", exact: true })
 			.click();
 
-		await expectDualModeState(page, aachenPath, aachenPath);
-		await expect(page.locator("#right h1")).toContainText("AACHEN, Hans von");
+		await expectDualModeState(page, artistOnePath, artistOnePath);
+		await expect(page.locator("#right h1")).toContainText(
+			"Synthetic Artist 01",
+		);
 	});
 
 	test("loads a left pane path through a standard GET form", async ({
 		page,
 	}) => {
-		await page.goto(dualModeURL(aachenPath, koedijckPath));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath));
 		const leftForm = page.getByRole("form", { name: "Load left pane" });
-		await leftForm.getByLabel("Load left pane path").fill(koedijckPath);
+		await leftForm.getByLabel("Load left pane path").fill(artistTwoPath);
 		await leftForm
 			.getByRole("button", { name: "Load left", exact: true })
 			.click();
 
-		await expectDualModeState(page, koedijckPath, koedijckPath);
-		await expect(page.locator("#left h1")).toContainText("KOEDIJCK, Isaack");
+		await expectDualModeState(page, artistTwoPath, artistTwoPath);
+		await expect(page.locator("#left h1")).toContainText("Synthetic Artist 02");
 	});
 
 	test("loads an artwork search result through standard links", async ({
 		page,
 	}) => {
-		await page.goto(dualModeURL(aachenPath, koedijckPath, "left", "right"));
+		await page.goto(dualModeURL(artistOnePath, artistTwoPath, "left", "right"));
 		await page.getByRole("link", { name: "Search right artworks" }).click();
 
-		await page.getByLabel("Title").fill("A Couple in a Tavern");
+		await page.getByLabel("Title").fill("Synthetic Artwork 01-01");
 		await page.getByRole("button", { name: "Search" }).click();
 		await page
 			.getByRole("link", {
-				name: "Open A Couple in a Tavern in right pane",
+				name: "Open Synthetic Artwork 01-01 in right pane",
 			})
 			.click();
 
 		await expectDualModeState(
 			page,
-			aachenPath,
-			aachenArtworkPath,
+			artistOnePath,
+			artistOneArtworkPath,
 			"left",
 			"right",
 		);
 		await expect(page.locator("#right h1")).toContainText(
-			"A Couple in a Tavern",
+			"Synthetic Artwork 01-01",
 		);
 	});
 });

--- a/playwright-tests/postcard.spec.ts
+++ b/playwright-tests/postcard.spec.ts
@@ -49,7 +49,9 @@ test("send postcard", async ({ page, request }) => {
 		expect(deleteResponse.ok()).toBeTruthy();
 	}
 
-	await page.goto("/artists/koedijck-isaack-3ed9e200b9e8252");
+	await page.goto(
+		"/artists/synthetic-artist-01-ad32608c6e36b2e/synthetic-artwork-01-01-2225c982be1af02",
+	);
 	await page.getByRole("link", { name: "Send postcard" }).click();
 
 	await expect(page.locator("#d")).toBeVisible();


### PR DESCRIPTION
This pull request introduces improvements to the guestbook feature, focusing on making the list of available years dynamic, caching the results for efficiency, and ensuring the cache is properly invalidated when guestbook entries change. It also adds comprehensive tests for the new logic and updates the UI to only prompt users to sign the guestbook for the current year.

**Guestbook Year Options and Caching:**

* The guestbook year options are now dynamically derived from existing entries rather than being hardcoded, and are cached for performance. The cache is invalidated automatically when guestbook entries are created, updated, or deleted. [[1]](diffhunk://#diff-88bbe8ebf49bf8eeda8be9449b4acc33183f2942fe2c9d6f88b748f1703be42bL35-R61) [[2]](diffhunk://#diff-6be2211641533ec1b6bb728f8a7103305fec21f14462490d99b85e46b95e0070R1-R18) [[3]](diffhunk://#diff-292fe7528f644bd69aba032b651f58c33ac7ca2c69abfba6e3d623233f593abcL3-R8) [[4]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82L15-R15) [[5]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82L26-R26) [[6]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82R48-R52) [[7]](diffhunk://#diff-9aef8579d781e3304a89aa690da4910e1a326d6517d6164215343f8ccfa508e0R15)
* The cache utility functions in `internal/utils/cache.go` now support deleting cached values and use a more generic `core.App` interface. [[1]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82L15-R15) [[2]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82L26-R26) [[3]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82R48-R52)
* Tests were added to ensure year options are distinct, descending, update after record changes, and that the cache is properly cleared. [[1]](diffhunk://#diff-72706b31f77a81d5abb8541948ac4fdd1b7f37bbb1e2efb9343c6f7106177430R1-R100) [[2]](diffhunk://#diff-f683ee48cda66b87fc59da3d85d8ea207acd0eaff03afafdb0e56282f548e094R47-R62)

**Guestbook UI Improvements:**

* The guestbook page now only prompts users to "Be the first to sign the guestbook" for the current year, not for previous years. [[1]](diffhunk://#diff-0d0c131d61f1b33f39e6ac806eaa35513089cded05d6448d4620fd13ea33271eR13) [[2]](diffhunk://#diff-0d0c131d61f1b33f39e6ac806eaa35513089cded05d6448d4620fd13ea33271eR89-R91) [[3]](diffhunk://#diff-88bbe8ebf49bf8eeda8be9449b4acc33183f2942fe2c9d6f88b748f1703be42bL81-R107) [[4]](diffhunk://#diff-2c4882074041b578e4b227e8bd48825d90ee9328df4d8c6b4ac42790b3cfbbceR1-R49)

**Codebase Consistency:**

* Refactored hook and utility function signatures to use the generic `core.App` interface instead of the concrete `pocketbase.PocketBase` type for improved flexibility and testability. [[1]](diffhunk://#diff-b689c5a220cc610024305f09db1440691c8e28b293e2b48a217b168cd6b847e0L4-R7) [[2]](diffhunk://#diff-ceef6481d2f3e64b56eb70f7d33f8bd4ea2b63402231a8ffef7016d2763aae82L15-R15) [[3]](diffhunk://#diff-292fe7528f644bd69aba032b651f58c33ac7ca2c69abfba6e3d623233f593abcL3-R8)

These changes make the guestbook feature more robust, efficient, and user-friendly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guestbook year filters are now generated from existing entry years, always including the current year.
  * The year selector shows only when multiple years are available.
  * The empty-state “first signer” prompt displays only when the selected year matches the current year.
* **Bug Fixes**
  * Guestbook year options refresh automatically after create/update/delete of entries.
  * Guestbook entry dates display in a consistent format.
* **Tests**
  * Updated/added Go tests for current-year behavior, selector rules, and year list refresh.
  * Updated Playwright tests to use synthetic fixtures and revised expected text/flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->