### PR TITLE
fix: correlate and redact application logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,22 @@
 - Edit Templ sources in `internal/assets/templ/`, then run `templ generate`. Adjacent `*_templ.go` files are generated and Git-ignored: do not edit or commit them.
 - Edit frontend sources in `resources/js/` and `resources/css/`; `bun run build` writes generated JS/CSS to `internal/assets/public/{js,css}`, which the Go binary embeds. `internal/assets/views/` and `internal/assets/reference/` are also embedded at build time.
 - The active Tailwind 4/daisyUI theme is in `resources/css/style.pcss`; UI work must also follow `.github/instructions/daisyui.instructions.md`.
+- Keep WGA as one deployable application. Extend the owning feature package and use explicit contracts across capability boundaries rather than reaching into another feature's persistence helpers.
+- Treat handlers and hooks as framework adapters: parse input, obtain request context, invoke the owning workflow, and map the result. Keep non-trivial business rules, state changes, and external side-effect ordering outside request handlers.
+- Load deployment settings only through `internal/config`; feature code must not read environment variables or `.env` files directly. Add parsing, validation, and focused tests there for new settings.
+- Use `logging.RequestLogger` for request-scoped work, `logging.RunLogger` for cron or background work, and `logging.Redact` for sensitive values. Request IDs are server-generated and public request headers are not trusted as their source.
+- For new direct third-party integrations, persist work before an external side effect when recovery or retry matters, and define idempotency before retries can repeat it.
+
+## Documentation map
+
+- `docs/development-guide.md` contains durable application design, configuration, external-work, logging, privacy, and delivery guidance.
+- `docs/documentation-maintenance.md` identifies the sources of truth and checks required when repository documentation changes.
+- `docs/features/` contains feature specifications and acceptance criteria.
+- Issue plans, review notes, and historical summaries are task-specific context, not current implementation guidance unless explicitly stated otherwise.
 
 ## Environment and development
 
-- Use Go 1.25.2 (`go.mod`/`mise.toml`), Bun, and Templ. `devenv shell` is the documented development environment; `mise` pins the same toolchain and exposes equivalent tasks as `mise run <task>`.
+- Use Go 1.26.5 (`go.mod`/`mise.toml`), Bun, and Templ. `devenv shell` is the documented development environment; `mise` pins the same toolchain and exposes equivalent tasks as `mise run <task>`.
 - Create `.env` from `.env.example` (`mise run app:init-env`). `godotenv.Load()` reads the default `.env` from the process working directory: `code:run` uses the repository root, while `app:run` changes into `dist/`.
 - `wga_data` is likewise relative to the process working directory. `app:run` uses `dist/wga_data`; clear the data directory used by the launcher rather than assuming root `wga_data` is the active one.
 - `mise run dev` brings up the Podman Compose Mailpit and Garage services, then starts JS/CSS/Templ watchers, but not the application server. Start it separately with `code:run`, or use `app:build` followed by `app:run`.
@@ -26,4 +38,4 @@
 - `biome.json` configures JS/TS tabs, double quotes, and import organisation. The Playwright CI workflow also runs Prettier on changed JS and Markdown files.
 - PR titles must use one of the Conventional Commit types enforced by `.github/workflows/pr-validation.yml`: `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `perf`, `chore`, `revert`, or `build`.
 - Non-`main` deployment runs only when the head commit message contains `deploy-dev`; release tags matching `v*.*.*` invoke GoReleaser.
-- When changing repository documentation, read `docs/documentation-maintenance.md`; it identifies the authoritative config and CI sources, including the Mailpit service and `MAILPIT_URL` endpoint.
+- When changing repository documentation, read `docs/documentation-maintenance.md` and `docs/development-guide.md`; the maintenance guide identifies the authoritative config and CI sources, including the Mailpit service and `MAILPIT_URL` endpoint.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Web Gallery of Art
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fblackfyre%2Fwga.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fblackfyre%2Fwga?ref=badge_shield)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/blackfyre/wga?utm_source=oss&utm_medium=github&utm_campaign=blackfyre%2Fwga&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 ## Introduction
 

--- a/cmd/wga/main.go
+++ b/cmd/wga/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/blackfyre/wga/internal/crontab"
 	"github.com/blackfyre/wga/internal/handlers"
 	"github.com/blackfyre/wga/internal/hooks"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/migrations"
 
 	"github.com/blackfyre/wga/internal/utils"
@@ -58,6 +59,7 @@ func main() {
 
 	if capability == commandNeedsServer {
 		utils.ConfigurePublicURL(serverConfig.PublicURL)
+		logging.RegisterRequestIDMiddleware(app)
 		handlers.RegisterHandlers(app, serverConfig.Captcha)
 		crontab.RegisterCronJobs(app, serverConfig.Postcards, serverConfig.Sitemap())
 	}

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -1,0 +1,49 @@
+# Development Guide
+
+## Purpose
+
+This guide records durable constraints for changes to WGA. It complements the repository workflow in `AGENTS.md` and the maintenance checklist in `docs/documentation-maintenance.md`.
+
+## Application structure
+
+WGA is one deployable application with feature-level boundaries. Keep related handlers, persistence access, scheduled work, and external adapters close to the capability that owns them. Do not introduce a separate service merely to organise a feature.
+
+`cmd/wga/main.go` is the composition root. It creates the application and registers routes, hooks, cron jobs, and migrations before starting the server. New capabilities should extend their owning package and be registered from the established entry points.
+
+When a change crosses capability boundaries, prefer an explicit input, query, or event contract over reaching into another capability's persistence helpers. Keep dependencies acyclic where practical.
+
+## HTTP, hooks, and business workflows
+
+Handlers and hooks are framework adapters. They should parse and validate transport input, obtain request context, invoke the owning workflow, and map the result to a response or framework action.
+
+Keep non-trivial workflow orchestration, product rules, state transitions, and external side-effect ordering outside request handlers. The same rule should remain reusable from a cron job, hook, or command without depending on an HTTP request object.
+
+Keep application-level failures distinct from malformed requests and framework failures. Do not leak framework, database, or provider errors directly into user-facing responses.
+
+## Configuration and storage
+
+Load deployment configuration through `internal/config`. Feature code must not read environment variables or `.env` files directly. Add parsing, validation, normalisation, and focused tests to that package when adding a setting.
+
+Configuration is resolved at process startup. Required settings must fail validation before the application serves traffic or starts scheduled work. Keep secrets out of errors, debug output, and logs.
+
+Use S3-compatible object storage for durable uploaded files. Do not make a local filesystem path the production system of record. Classify new file types as public or restricted; treat an unclassified type as restricted, and require authorisation plus time-bounded access for restricted files.
+
+## Scheduled and external work
+
+Cron jobs and other non-request executions start a fresh `run_id`. Preserve a stable correlation value when work continues an earlier flow, but do not reuse the originating execution identifier as the current run identifier.
+
+For a new direct third-party integration, record work durably before attempting the external side effect when traceability, recovery, or retry matters. Define duplicate suppression or idempotency before automatic retries can repeat an external action. Make terminal outcomes explicit and retain only the data required to operate and diagnose the integration.
+
+Classify failures at the adapter that understands the dependency. Retry only failures that can succeed unchanged; leave deterministic input, credential, configuration, contract, and code failures for explicit resolution rather than retrying them indefinitely.
+
+## Logging and personal data
+
+Use structured log attributes, not interpolated diagnostic strings. Attach the request-scoped logger for HTTP work and the run-scoped logger for cron or background work. WGA generates request identifiers at ingress and does not trust public request headers as an identifier source.
+
+Use `logging.Redact` for values that may contain personal data, credentials, tokens, or payload content. Prefer internal record identifiers over names, email addresses, addresses, or raw user input. Logs and operational records must retain the minimum data needed for support and must not become a substitute for durable business history.
+
+When a feature stores personal data, define its purpose and retention outcome. Remove or anonymise data that is no longer needed, including copies in uploads, exports, and operational by-products.
+
+## Delivery discipline
+
+Use Conventional Commit types for commits and pull-request titles. Keep documentation aligned with the executable configuration and CI workflow; task plans, review notes, and historical summaries are not a substitute for current guidance.

--- a/docs/issue-177-safe-correlated-logging-plan.md
+++ b/docs/issue-177-safe-correlated-logging-plan.md
@@ -1,0 +1,37 @@
+# Issue 177 Safe Correlated Logging Plan
+
+## Introduction
+
+Issue #177 removes personally identifiable and secret request data from application logs while making request and postcard-delivery logs correlatable. PocketBase persists structured `slog` attributes as JSON log data, so the implementation will use stable fields and local logger instances rather than a separate logging backend.
+
+## Phase 1: Correlation and redaction foundation
+
+### Request and run scopes
+
+- [✓] Inspect the existing handler, cron, hook, and contributor logging paths. Verification: each unsafe or uncorrelated logging call is identified before editing.
+- [✓] Add request-ID middleware at the global PocketBase router ingress, including request context propagation and an `X-Request-ID` response header. Verification: one request retains the same non-empty `request_id` in its context and structured logs.
+- [✓] Add request/run logger helpers and an explicit redaction utility. Verification: emitted fields use stable names and redacted values never contain their inputs.
+
+## Phase 2: Safe application logs
+
+### Request handlers and integrations
+
+- [✓] Replace postcard handler logs with event names, safe outcomes, and request-scoped loggers. Verification: captured postcard logs do not contain form data, captcha tokens, email addresses, message bodies, IP addresses, or postcard pickup identifiers.
+- [✓] Pass correlation context through the contributors repository and return generic contributor failures. Verification: contributor diagnostics are redacted and HTTP responses contain no internal error text.
+- [✓] Replace file-hook event serialisation with selected safe fields. Verification: captured file-download logs exclude the request object, paths, names, headers, and body data.
+
+### Scheduled delivery
+
+- [✓] Generate one `run_id` per postcard cron callback and include it in delivery, rendering, record-update, and run-result logs. Verification: all captured delivery records for a run share its `run_id`, include only safe execution IDs, attempt, and outcome fields, and failed deliveries remain queued.
+
+## Phase 3: Verification and delivery
+
+### Automated coverage
+
+- [✓] Add focused identifier-propagation, captured-log redaction, delivery-field, and generic HTTP-error tests. Verification: known sensitive markers fail the tests if they appear in captured logs or contributor responses.
+- [ ] Run formatting, focused tests, `go vet ./...`, and `go test ./... -cover`. Verification: all selected commands pass. Blocked: the unrelated `TestConfigurationParsesTypedValues` still expects SMTP port 1025 while the working tree changes its fixture to 1525.
+
+### Review
+
+- [ ] Manually check the changed log field names and contributor error response. Verification: operator-visible output meets the issue acceptance criteria.
+- [ ] Commit and push the approved change. Verification: commit contains only issue #177 files and no credentials or generated artefacts.

--- a/docs/issue-177-safe-correlated-logging-plan.md
+++ b/docs/issue-177-safe-correlated-logging-plan.md
@@ -22,7 +22,7 @@ Issue #177 removes personally identifiable and secret request data from applicat
 
 ### Scheduled delivery
 
-- [✓] Generate one `run_id` per postcard cron callback and include it in delivery, rendering, record-update, and run-result logs. Verification: all captured delivery records for a run share its `run_id`, include only safe execution IDs, attempt, and outcome fields, and failed deliveries remain queued.
+- [✓] Generate one `run_id` per postcard cron callback and include it in delivery, rendering, record-update, and run-result logs. Verification: all captured delivery records for a run share its `run_id`, include only safe execution IDs, attempt, and outcome fields, and every recipient is attempted before terminalising the postcard.
 
 ## Phase 3: Verification and delivery
 

--- a/docs/issue-177-safe-correlated-logging-plan.md
+++ b/docs/issue-177-safe-correlated-logging-plan.md
@@ -34,4 +34,4 @@ Issue #177 removes personally identifiable and secret request data from applicat
 ### Review
 
 - [ ] Manually check the changed log field names and contributor error response. Verification: operator-visible output meets the issue acceptance criteria.
-- [ ] Commit and push the approved change. Verification: commit contains only issue #177 files and no credentials or generated artefacts.
+- [✓] Commit and push the approved change. Verification: commit contains only issue #177 files and no credentials or generated artefacts.

--- a/internal/crontab/postcard.go
+++ b/internal/crontab/postcard.go
@@ -15,23 +15,26 @@ import (
 // sendPostcard sends a postcard to every recipient and reports whether all deliveries succeeded.
 func sendPostcard(r *core.Record, app core.App, mailClient mailer.Mailer, postcards config.Postcards, runID string) bool {
 	recipients := convertCommaSeparatedEmailsToMailAddresses(r.GetString("recipients"))
+	allDelivered := true
 
 	for index, rec := range recipients {
 		message, err := renderMessage(r, rec, postcards)
 		if err != nil {
 			logPostcardDelivery(app, runID, index+1, len(recipients), "render_failed", err)
-			return false
+			allDelivered = false
+			continue
 		}
 
 		if err := mailClient.Send(message); err != nil {
 			logPostcardDelivery(app, runID, index+1, len(recipients), "failed", err)
-			return false
+			allDelivered = false
+			continue
 		}
 
 		logPostcardDelivery(app, runID, index+1, len(recipients), "sent", nil)
 	}
 
-	return true
+	return allDelivered
 }
 
 // convertCommaSeparatedEmailsToMailAddresses converts a comma-separated string of email addresses
@@ -114,11 +117,12 @@ func logPostcardDelivery(app core.App, runID string, recipientIndex int, recipie
 }
 
 func processPostcard(r *core.Record, app core.App, mailClient mailer.Mailer, postcards config.Postcards, runID string) bool {
-	if !sendPostcard(r, app, mailClient, postcards, runID) {
+	allDelivered := sendPostcard(r, app, mailClient, postcards, runID)
+	if !updatePostcardRecord(r, app, runID) {
 		return false
 	}
 
-	return updatePostcardRecord(r, app, runID)
+	return allDelivered
 }
 
 // sendPostcards sends postcards based on a specified frequency.

--- a/internal/crontab/postcard.go
+++ b/internal/crontab/postcard.go
@@ -7,33 +7,31 @@ import (
 
 	"github.com/blackfyre/wga/internal/assets"
 	"github.com/blackfyre/wga/internal/config"
-	"github.com/pocketbase/pocketbase"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tools/mailer"
 )
 
-// sendPostcard sends a postcard to the recipients specified in the given record.
-// It takes a pointer to a models.Record, a pointer to a pocketbase.PocketBase, and a mailer.Mailer as parameters.
-// The recipients are extracted from the "recipients" field of the record and split into a slice of mail.Address.
-// For each recipient, a postcard message is rendered using the renderMessage function.
-// The message is then sent using the mailClient.
-// If there is an error sending the postcard, an error message is logged and the function returns.
-// Finally, the postcard record is updated using the updatePostcardRecord function.
-func sendPostcard(r *core.Record, app *pocketbase.PocketBase, mailClient mailer.Mailer, postcards config.Postcards) {
-
+// sendPostcard sends a postcard to every recipient and reports whether all deliveries succeeded.
+func sendPostcard(r *core.Record, app core.App, mailClient mailer.Mailer, postcards config.Postcards, runID string) bool {
 	recipients := convertCommaSeparatedEmailsToMailAddresses(r.GetString("recipients"))
 
-	for _, rec := range recipients {
-
-		message := renderMessage(r, rec, app, postcards)
-
-		err := mailClient.Send(message)
-
+	for index, rec := range recipients {
+		message, err := renderMessage(r, rec, postcards)
 		if err != nil {
-			app.Logger().Error("Error sending email", "error", err.Error())
-			return
+			logPostcardDelivery(app, runID, index+1, len(recipients), "render_failed", err)
+			return false
 		}
+
+		if err := mailClient.Send(message); err != nil {
+			logPostcardDelivery(app, runID, index+1, len(recipients), "failed", err)
+			return false
+		}
+
+		logPostcardDelivery(app, runID, index+1, len(recipients), "sent", nil)
 	}
+
+	return true
 }
 
 // convertCommaSeparatedEmailsToMailAddresses converts a comma-separated string of email addresses
@@ -50,9 +48,7 @@ func convertCommaSeparatedEmailsToMailAddresses(emails string) []mail.Address {
 }
 
 // renderMessage renders the email message for a postcard notification.
-// It takes a pointer to a models.Record, a mail.Address, and a pointer to a pocketbase.PocketBase as input.
-// It returns a pointer to a mailer.Message.
-func renderMessage(r *core.Record, rec mail.Address, app *pocketbase.PocketBase, postcards config.Postcards) *mailer.Message {
+func renderMessage(r *core.Record, rec mail.Address, postcards config.Postcards) (*mailer.Message, error) {
 	html, err := assets.RenderEmail("postcard:notification", map[string]any{
 		"SenderName": r.GetString("sender_name"),
 		"PickUpUrl":  postcards.PublicURL.Resolve("/postcard?p=" + r.GetString("id")),
@@ -61,8 +57,7 @@ func renderMessage(r *core.Record, rec mail.Address, app *pocketbase.PocketBase,
 	})
 
 	if err != nil {
-		app.Logger().Error("Error rendering postcard email", "error", err.Error())
-		return &mailer.Message{}
+		return nil, err
 	}
 
 	message := &mailer.Message{
@@ -75,21 +70,55 @@ func renderMessage(r *core.Record, rec mail.Address, app *pocketbase.PocketBase,
 		HTML:    html,
 	}
 
-	return message
+	return message, nil
 }
 
-// updatePostcardRecord updates the postcard record with the given status and sent_at timestamp.
-// It takes a pointer to a models.Record object and a pointer to a pocketbase.PocketBase object as parameters.
-// The function sets the "status" field of the record to "sent" and the "sent_at" field to the current Unix timestamp.
-// It then saves the updated record using the SaveRecord method of the pocketbase.PocketBase object.
-// If there is an error during the update, it logs the error using the Logger method of the pocketbase.PocketBase object.
-func updatePostcardRecord(r *core.Record, app *pocketbase.PocketBase) {
+// updatePostcardRecord marks a successfully delivered postcard as sent.
+func updatePostcardRecord(r *core.Record, app core.App, runID string) bool {
 	r.Set("status", "sent")
 	r.Set("sent_at", time.Now().Unix())
 
 	if err := app.Save(r); err != nil {
-		app.Logger().Error("Error updating postcard record", "record_id", r.Get("id"), "error", err.Error())
+		logging.RunLogger(app, runID).Error("Postcard delivery record update failed",
+			"event", "postcard.delivery.record_update",
+			"outcome", "failed",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
+		return false
 	}
+
+	return true
+}
+
+func logPostcardDelivery(app core.App, runID string, recipientIndex int, recipientCount int, outcome string, err error) {
+	attributes := []any{
+		"event", "postcard.delivery.attempt",
+		"recipient_index", recipientIndex,
+		"recipient_count", recipientCount,
+		"attempt", 1,
+		"outcome", outcome,
+	}
+	logger := logging.RunLogger(app, runID)
+
+	if err == nil {
+		logger.Info("Postcard delivery completed", attributes...)
+		return
+	}
+
+	attributes = append(attributes,
+		"error_type", logging.ErrorType(err),
+		"error", logging.Redact(err),
+	)
+	logger.Error("Postcard delivery failed", attributes...)
+}
+
+func processPostcard(r *core.Record, app core.App, mailClient mailer.Mailer, postcards config.Postcards, runID string) bool {
+	if !sendPostcard(r, app, mailClient, postcards, runID) {
+		return false
+	}
+
+	return updatePostcardRecord(r, app, runID)
 }
 
 // sendPostcards sends postcards based on a specified frequency.
@@ -106,11 +135,17 @@ func updatePostcardRecord(r *core.Record, app *pocketbase.PocketBase) {
 //	sendPostcards(app, postcards)
 //
 // Note: The sendPostcards function assumes that the necessary dependencies are already imported.
-func sendPostcards(app *pocketbase.PocketBase, postcards config.Postcards) {
-
-	app.Logger().Info("Starting postcard cron job...")
+func sendPostcards(app core.App, postcards config.Postcards) {
+	app.Logger().Info("Postcard delivery schedule registered", "event", "postcard.delivery.schedule_registered")
 
 	app.Cron().MustAdd("postcards", postcards.Expression(), func() {
+		runID := logging.NewRunID()
+		logger := logging.RunLogger(app, runID)
+		logger.Info("Postcard delivery run started",
+			"event", "postcard.delivery.run",
+			"outcome", "started",
+		)
+
 		records, err := app.FindRecordsByFilter(
 			"postcards",         // collection
 			"status = 'queued'", // filter
@@ -120,16 +155,50 @@ func sendPostcards(app *pocketbase.PocketBase, postcards config.Postcards) {
 		)
 
 		if err != nil {
-			app.Logger().Error("Error fetching postcards", "error", err.Error())
+			logger.Error("Postcard delivery queue lookup failed",
+				"event", "postcard.delivery.run",
+				"outcome", "queue_lookup_failed",
+				"error_type", logging.ErrorType(err),
+				"error", logging.Redact(err),
+			)
 			return
 		}
 
 		mailClient := app.NewMailClient()
+		deliveredCount := 0
+		failedCount := 0
 
 		for _, r := range records {
-			sendPostcard(r, app, mailClient, postcards)
-			updatePostcardRecord(r, app)
+			if !processPostcard(r, app, mailClient, postcards, runID) {
+				failedCount++
+				continue
+			}
+
+			deliveredCount++
 		}
+
+		if failedCount > 0 {
+			outcome := "partial_failure"
+			if deliveredCount == 0 {
+				outcome = "failed"
+			}
+
+			logger.Warn("Postcard delivery run completed",
+				"event", "postcard.delivery.run",
+				"postcard_count", len(records),
+				"delivered_count", deliveredCount,
+				"failed_count", failedCount,
+				"outcome", outcome,
+			)
+			return
+		}
+
+		logger.Info("Postcard delivery run completed",
+			"event", "postcard.delivery.run",
+			"postcard_count", len(records),
+			"delivered_count", deliveredCount,
+			"outcome", "completed",
+		)
 	})
 
 }

--- a/internal/crontab/postcard_test.go
+++ b/internal/crontab/postcard_test.go
@@ -1,11 +1,19 @@
 package crontab
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
 	"net/mail"
 	"strings"
 	"testing"
 
+	"github.com/blackfyre/wga/internal/config"
 	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
 	"github.com/pocketbase/pocketbase/tools/mailer"
 )
 
@@ -16,8 +24,6 @@ func TestSendMail(t *testing.T) {
 	})
 
 	mailClient := app.NewMailClient()
-
-	t.Logf("mailClient: %v", mailClient)
 
 	message := &mailer.Message{
 		From: mail.Address{
@@ -43,4 +49,180 @@ func TestSendMail(t *testing.T) {
 		t.Errorf("sendMail returned an error: %v", err)
 	}
 
+}
+
+func TestLogPostcardDeliveryUsesSafeRunFields(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	app.Settings().Logs.MaxDays = 1
+	captured := captureDeliveryLogs(app)
+
+	logPostcardDelivery(
+		app,
+		"run-123",
+		1,
+		2,
+		"sent",
+		nil,
+	)
+	logPostcardDelivery(
+		app,
+		"run-123",
+		2,
+		2,
+		"failed",
+		errors.New("recipient@example.test token-value message-body-value"),
+	)
+
+	flushDeliveryLogs(t, app)
+	entries := deliveryLogsWithEvent(captured(), "postcard.delivery.attempt")
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 postcard delivery logs, got %d", len(entries))
+	}
+	var failedEntry *core.Log
+	for _, entry := range entries {
+		if got := entry.Data["run_id"]; got != "run-123" {
+			t.Fatalf("run_id = %v, want %q", got, "run-123")
+		}
+		if entry.Data["outcome"] == "failed" {
+			failedEntry = entry
+		}
+	}
+	if failedEntry == nil {
+		t.Fatal("expected a failed postcard delivery log")
+	}
+	entry := failedEntry
+	if _, ok := entry.Data["postcard_id"]; ok {
+		t.Fatal("delivery log must not contain the postcard pickup identifier")
+	}
+	if got := fmt.Sprint(entry.Data["attempt"]); got != "1" {
+		t.Fatalf("attempt = %s, want 1", got)
+	}
+	if got := entry.Data["outcome"]; got != "failed" {
+		t.Fatalf("outcome = %v, want %q", got, "failed")
+	}
+
+	output := fmt.Sprint(deliveryLogData(captured()))
+	for _, sensitive := range []string{"recipient@example.test", "token-value", "message-body-value"} {
+		if strings.Contains(output, sensitive) {
+			t.Fatalf("captured log contains %q: %s", sensitive, output)
+		}
+	}
+}
+
+func TestProcessPostcardLeavesFailedDeliveryQueued(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	collection := core.NewBaseCollection("postcards")
+	collection.Fields.Add(
+		&core.TextField{Name: "status"},
+		&core.TextField{Name: "recipients"},
+		&core.TextField{Name: "sender_name"},
+	)
+	if err := app.Save(collection); err != nil {
+		t.Fatalf("create postcards collection: %v", err)
+	}
+
+	record := core.NewRecord(collection)
+	record.Set("status", "queued")
+	record.Set("recipients", "recipient@example.test")
+	record.Set("sender_name", "sender")
+	if err := app.Save(record); err != nil {
+		t.Fatalf("create postcard: %v", err)
+	}
+
+	if processPostcard(record, app, failingMailer{}, postcardTestConfig(t), "run-123") {
+		t.Fatal("expected postcard delivery to fail")
+	}
+
+	stored, err := app.FindRecordById(collection.Id, record.Id)
+	if err != nil {
+		t.Fatalf("reload postcard: %v", err)
+	}
+	if got := stored.GetString("status"); got != "queued" {
+		t.Fatalf("status = %q, want %q", got, "queued")
+	}
+}
+
+type failingMailer struct{}
+
+func (failingMailer) Send(*mailer.Message) error {
+	return errors.New("mail transport failed")
+}
+
+func postcardTestConfig(t *testing.T) config.Postcards {
+	t.Helper()
+
+	values := map[string]string{
+		"WGA_ENV":            "test",
+		"WGA_PROTOCOL":       "http",
+		"WGA_HOSTNAME":       "example.test",
+		"WGA_SENDER_NAME":    "WGA",
+		"WGA_SENDER_ADDRESS": "sender@example.test",
+	}
+	runtimeConfig := config.LoadFrom(func(key string) string {
+		return values[key]
+	})
+	server, err := runtimeConfig.Server()
+	if err != nil {
+		t.Fatalf("load postcard config: %v", err)
+	}
+
+	return server.Postcards
+}
+
+func captureDeliveryLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+func flushDeliveryLogs(t *testing.T, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+func deliveryLogsWithEvent(logs []*core.Log, event string) []*core.Log {
+	entries := []*core.Log{}
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+func deliveryLogData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
 }

--- a/internal/crontab/postcard_test.go
+++ b/internal/crontab/postcard_test.go
@@ -1,19 +1,17 @@
 package crontab
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/mail"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/blackfyre/wga/internal/config"
+	"github.com/blackfyre/wga/internal/testutils"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tests"
-	"github.com/pocketbase/pocketbase/tools/logger"
 	"github.com/pocketbase/pocketbase/tools/mailer"
 )
 
@@ -52,13 +50,8 @@ func TestSendMail(t *testing.T) {
 }
 
 func TestLogPostcardDeliveryUsesSafeRunFields(t *testing.T) {
-	app, err := tests.NewTestApp()
-	if err != nil {
-		t.Fatalf("create test app: %v", err)
-	}
-	t.Cleanup(app.Cleanup)
-	app.Settings().Logs.MaxDays = 1
-	captured := captureDeliveryLogs(app)
+	app := testutils.NewTestApp(t)
+	captured := testutils.CaptureLogs(app)
 
 	logPostcardDelivery(
 		app,
@@ -77,8 +70,8 @@ func TestLogPostcardDeliveryUsesSafeRunFields(t *testing.T) {
 		errors.New("recipient@example.test token-value message-body-value"),
 	)
 
-	flushDeliveryLogs(t, app)
-	entries := deliveryLogsWithEvent(captured(), "postcard.delivery.attempt")
+	testutils.FlushLogs(t, app)
+	entries := testutils.LogsWithEvent(captured(), "postcard.delivery.attempt")
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 postcard delivery logs, got %d", len(entries))
 	}
@@ -105,7 +98,7 @@ func TestLogPostcardDeliveryUsesSafeRunFields(t *testing.T) {
 		t.Fatalf("outcome = %v, want %q", got, "failed")
 	}
 
-	output := fmt.Sprint(deliveryLogData(captured()))
+	output := fmt.Sprint(testutils.LogData(captured()))
 	for _, sensitive := range []string{"recipient@example.test", "token-value", "message-body-value"} {
 		if strings.Contains(output, sensitive) {
 			t.Fatalf("captured log contains %q: %s", sensitive, output)
@@ -113,12 +106,8 @@ func TestLogPostcardDeliveryUsesSafeRunFields(t *testing.T) {
 	}
 }
 
-func TestProcessPostcardLeavesFailedDeliveryQueued(t *testing.T) {
-	app, err := tests.NewTestApp()
-	if err != nil {
-		t.Fatalf("create test app: %v", err)
-	}
-	t.Cleanup(app.Cleanup)
+func TestProcessPostcardCompletesAfterPartialDeliveryFailure(t *testing.T) {
+	app := testutils.NewTestApp(t)
 	collection := core.NewBaseCollection("postcards")
 	collection.Fields.Add(
 		&core.TextField{Name: "status"},
@@ -131,29 +120,48 @@ func TestProcessPostcardLeavesFailedDeliveryQueued(t *testing.T) {
 
 	record := core.NewRecord(collection)
 	record.Set("status", "queued")
-	record.Set("recipients", "recipient@example.test")
+	record.Set("recipients", "first@example.test,second@example.test,third@example.test")
 	record.Set("sender_name", "sender")
 	if err := app.Save(record); err != nil {
 		t.Fatalf("create postcard: %v", err)
 	}
 
-	if processPostcard(record, app, failingMailer{}, postcardTestConfig(t), "run-123") {
+	mailClient := &scriptedMailer{
+		outcomes: []error{nil, errors.New("mail transport failed"), nil},
+	}
+	if processPostcard(record, app, mailClient, postcardTestConfig(t), "run-123") {
 		t.Fatal("expected postcard delivery to fail")
+	}
+	wantRecipients := []string{"first@example.test", "second@example.test", "third@example.test"}
+	if !reflect.DeepEqual(mailClient.recipients, wantRecipients) {
+		t.Fatalf("attempted recipients = %v, want %v", mailClient.recipients, wantRecipients)
 	}
 
 	stored, err := app.FindRecordById(collection.Id, record.Id)
 	if err != nil {
 		t.Fatalf("reload postcard: %v", err)
 	}
-	if got := stored.GetString("status"); got != "queued" {
-		t.Fatalf("status = %q, want %q", got, "queued")
+	if got := stored.GetString("status"); got != "sent" {
+		t.Fatalf("status = %q, want %q", got, "sent")
+	}
+	queuedRecords, err := app.FindRecordsByFilter(collection.Id, "status = 'queued'", "", 0, 0)
+	if err != nil {
+		t.Fatalf("load queued postcards: %v", err)
+	}
+	if len(queuedRecords) != 0 {
+		t.Fatalf("queued postcards = %d, want 0", len(queuedRecords))
 	}
 }
 
-type failingMailer struct{}
+type scriptedMailer struct {
+	outcomes   []error
+	recipients []string
+}
 
-func (failingMailer) Send(*mailer.Message) error {
-	return errors.New("mail transport failed")
+func (m *scriptedMailer) Send(message *mailer.Message) error {
+	m.recipients = append(m.recipients, message.To[0].Address)
+
+	return m.outcomes[len(m.recipients)-1]
 }
 
 func postcardTestConfig(t *testing.T) config.Postcards {
@@ -175,54 +183,4 @@ func postcardTestConfig(t *testing.T) config.Postcards {
 	}
 
 	return server.Postcards
-}
-
-func captureDeliveryLogs(app *tests.TestApp) func() []*core.Log {
-	var captured []*core.Log
-	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
-		log, ok := e.Model.(*core.Log)
-		if ok {
-			entry := *log
-			entry.Data = maps.Clone(log.Data)
-			captured = append(captured, &entry)
-		}
-
-		return e.Next()
-	})
-
-	return func() []*core.Log {
-		return captured
-	}
-}
-
-func flushDeliveryLogs(t *testing.T, app *tests.TestApp) {
-	t.Helper()
-
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	if err := handler.WriteAll(context.Background()); err != nil {
-		t.Fatalf("write logs: %v", err)
-	}
-}
-
-func deliveryLogsWithEvent(logs []*core.Log, event string) []*core.Log {
-	entries := []*core.Log{}
-	for _, entry := range logs {
-		if entry.Data["event"] == event {
-			entries = append(entries, entry)
-		}
-	}
-
-	return entries
-}
-
-func deliveryLogData(logs []*core.Log) []any {
-	data := make([]any, len(logs))
-	for index, entry := range logs {
-		data[index] = entry.Data
-	}
-
-	return data
 }

--- a/internal/handlers/contributors/main.go
+++ b/internal/handlers/contributors/main.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
 	tmplUtils "github.com/blackfyre/wga/internal/assets/templ/utils"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/repositories"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/pocketbase/pocketbase"
-	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
 
@@ -21,14 +21,17 @@ func RegisterHandlers(app *pocketbase.PocketBase) {
 			pushUrl := utils.GenerateCurrentRelativePageUrl(c)
 			repo := repositories.NewContributorsRepository(app)
 
-			contributors, source, err := repo.GetContributorsWithSource()
+			contributors, source, err := repo.GetContributorsWithSource(c.Request.Context())
 			if err != nil {
-				app.Logger().Error("Error getting contributors", "error", err)
-				return apis.NewApiError(500, err.Error(), err)
+				return contributorServerError(app, c, "fetch_error", err)
 			}
 
 			if source == repositories.ContributorsSourceFileFallback {
-				app.Logger().Warn("Contributors endpoint served fallback data", "source", source)
+				logging.RequestLogger(app, c).Warn("Contributors fallback served",
+					"event", "contributors.request.completed",
+					"outcome", "fallback",
+					"source", source,
+				)
 			}
 
 			content := pages.ContributorsPageDTO{
@@ -48,8 +51,7 @@ func RegisterHandlers(app *pocketbase.PocketBase) {
 			err = pages.ContributorsPage(content).Render(ctx, &buf)
 
 			if err != nil {
-				app.Logger().Error("Error rendering artwork page", "error", err.Error())
-				return c.Error(http.StatusInternalServerError, "failed to render response template", err)
+				return contributorServerError(app, c, "render_error", err)
 			}
 
 			return c.HTML(http.StatusOK, buf.String())
@@ -58,4 +60,15 @@ func RegisterHandlers(app *pocketbase.PocketBase) {
 
 		return se.Next()
 	})
+}
+
+func contributorServerError(app core.App, c *core.RequestEvent, outcome string, err error) error {
+	logging.RequestLogger(app, c).Error("Contributors request failed",
+		"event", "contributors.request.failed",
+		"outcome", outcome,
+		"error_type", logging.ErrorType(err),
+		"error", logging.Redact(err),
+	)
+
+	return c.InternalServerError("Unable to load contributors.", nil)
 }

--- a/internal/handlers/contributors/main_test.go
+++ b/internal/handlers/contributors/main_test.go
@@ -1,0 +1,112 @@
+package contributors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
+)
+
+func TestContributorServerErrorIsClientSafe(t *testing.T) {
+	const sensitiveDetail = "upstream credential token=secret-value"
+	var captured func() []*core.Log
+
+	scenario := tests.ApiScenario{
+		Name:           "contributor failure omits internal detail",
+		Method:         http.MethodGet,
+		URL:            "/contributors-error",
+		ExpectedStatus: http.StatusInternalServerError,
+		ExpectedContent: []string{
+			"Unable to load contributors.",
+		},
+		NotExpectedContent: []string{
+			sensitiveDetail,
+		},
+		TestAppFactory: func(t testing.TB) *tests.TestApp {
+			app, err := tests.NewTestApp()
+			if err != nil {
+				t.Fatalf("create test app: %v", err)
+			}
+			app.Settings().Logs.MaxDays = 1
+			captured = captureContributorLogs(app)
+
+			app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+				se.Router.GET("/contributors-error", func(e *core.RequestEvent) error {
+					return contributorServerError(app, e, "fetch_error", errors.New(sensitiveDetail))
+				})
+
+				return se.Next()
+			})
+
+			return app
+		},
+		AfterTestFunc: func(t testing.TB, app *tests.TestApp, _ *http.Response) {
+			flushContributorLogs(t, app)
+			entry := contributorLogWithEvent(captured(), "contributors.request.failed")
+			if entry == nil {
+				t.Fatal("expected a contributor failure log")
+			}
+			if strings.Contains(fmt.Sprint(contributorLogData(captured())), sensitiveDetail) {
+				t.Fatalf("captured log contains %q", sensitiveDetail)
+			}
+		},
+	}
+
+	scenario.Test(t)
+}
+
+func captureContributorLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+func flushContributorLogs(t testing.TB, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+func contributorLogWithEvent(logs []*core.Log, event string) *core.Log {
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+func contributorLogData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
+}

--- a/internal/handlers/contributors/main_test.go
+++ b/internal/handlers/contributors/main_test.go
@@ -1,17 +1,15 @@
 package contributors
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/blackfyre/wga/internal/testutils"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
-	"github.com/pocketbase/pocketbase/tools/logger"
 )
 
 func TestContributorServerErrorIsClientSafe(t *testing.T) {
@@ -35,7 +33,7 @@ func TestContributorServerErrorIsClientSafe(t *testing.T) {
 				t.Fatalf("create test app: %v", err)
 			}
 			app.Settings().Logs.MaxDays = 1
-			captured = captureContributorLogs(app)
+			captured = testutils.CaptureLogs(app)
 
 			app.OnServe().BindFunc(func(se *core.ServeEvent) error {
 				se.Router.GET("/contributors-error", func(e *core.RequestEvent) error {
@@ -48,65 +46,16 @@ func TestContributorServerErrorIsClientSafe(t *testing.T) {
 			return app
 		},
 		AfterTestFunc: func(t testing.TB, app *tests.TestApp, _ *http.Response) {
-			flushContributorLogs(t, app)
-			entry := contributorLogWithEvent(captured(), "contributors.request.failed")
+			testutils.FlushLogs(t, app)
+			entry := testutils.LogWithEvent(captured(), "contributors.request.failed")
 			if entry == nil {
 				t.Fatal("expected a contributor failure log")
 			}
-			if strings.Contains(fmt.Sprint(contributorLogData(captured())), sensitiveDetail) {
+			if strings.Contains(fmt.Sprint(testutils.LogData(captured())), sensitiveDetail) {
 				t.Fatalf("captured log contains %q", sensitiveDetail)
 			}
 		},
 	}
 
 	scenario.Test(t)
-}
-
-func captureContributorLogs(app *tests.TestApp) func() []*core.Log {
-	var captured []*core.Log
-	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
-		log, ok := e.Model.(*core.Log)
-		if ok {
-			entry := *log
-			entry.Data = maps.Clone(log.Data)
-			captured = append(captured, &entry)
-		}
-
-		return e.Next()
-	})
-
-	return func() []*core.Log {
-		return captured
-	}
-}
-
-func flushContributorLogs(t testing.TB, app *tests.TestApp) {
-	t.Helper()
-
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	if err := handler.WriteAll(context.Background()); err != nil {
-		t.Fatalf("write logs: %v", err)
-	}
-}
-
-func contributorLogWithEvent(logs []*core.Log, event string) *core.Log {
-	for _, entry := range logs {
-		if entry.Data["event"] == event {
-			return entry
-		}
-	}
-
-	return nil
-}
-
-func contributorLogData(logs []*core.Log) []any {
-	data := make([]any, len(logs))
-	for index, entry := range logs {
-		data[index] = entry.Data
-	}
-
-	return data
 }

--- a/internal/handlers/postcards/save.go
+++ b/internal/handlers/postcards/save.go
@@ -2,21 +2,21 @@ package postcards
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/blackfyre/wga/internal/config"
 	"github.com/blackfyre/wga/internal/constants"
 	"github.com/blackfyre/wga/internal/errs"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/validation"
 	"github.com/microcosm-cc/bluemonday"
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonday.Policy, captcha config.Captcha) error {
+func savePostcard(app core.App, c *core.RequestEvent, p *bluemonday.Policy, captcha config.Captcha) error {
+	logger := logging.RequestLogger(app, c)
 	postData := struct {
 		SenderName           string   `json:"sender_name" form:"sender_name" query:"sender_name" validate:"required"`
 		SenderEmail          string   `json:"sender_email" form:"sender_email" query:"sender_email" validate:"required,email"`
@@ -30,14 +30,22 @@ func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonda
 	}{}
 
 	if err := c.BindBody(&postData); err != nil {
-		app.Logger().Error("Failed to parse form", "error", err.Error())
+		logger.Error("Postcard submission parsing failed",
+			"event", "postcard.submission.failed",
+			"outcome", "invalid_payload",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		utils.SendToastMessage("Failed to parse form", "error", true, c, "")
 		return utils.ServerFaultError(c)
 	}
 
 	if err := validation.ValidateHoneypot(postData.HoneyPotName, postData.HoneyPotEmail); err != nil {
 		if errors.Is(err, errs.ErrHoneypotTriggered) {
-			app.Logger().Warn("Honey pot triggered", "data", fmt.Sprintf("%+v", postData), "ip", c.RealIP())
+			logger.Warn("Postcard submission rejected",
+				"event", "postcard.submission.rejected",
+				"outcome", "honeypot",
+			)
 			return utils.ServerFaultError(c)
 		}
 
@@ -45,6 +53,10 @@ func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonda
 	}
 
 	if err := validation.ValidateRecaptchaToken(postData.RecaptchaToken); err != nil {
+		logger.Warn("Postcard submission rejected",
+			"event", "postcard.submission.rejected",
+			"outcome", "invalid_captcha_token",
+		)
 		utils.SendToastMessage("Captcha verification failed", "error", true, c, "")
 		return utils.BadRequestError(c)
 	}
@@ -52,23 +64,39 @@ func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonda
 	if captcha.Verify() {
 		verified, err := verifyRecaptchaToken(c.Request.Context(), http.DefaultClient, captcha.Secret(), postData.RecaptchaToken, c.RealIP())
 		if err != nil {
-			app.Logger().Error("Failed to verify recaptcha token", "error", err.Error())
+			logger.Error("Postcard captcha verification failed",
+				"event", "postcard.captcha.failed",
+				"outcome", "provider_error",
+				"error_type", logging.ErrorType(err),
+				"error", logging.Redact(err),
+			)
 			utils.SendToastMessage("Failed to verify captcha", "error", true, c, "")
 			return utils.ServerFaultError(c)
 		}
 
 		if !verified {
-			app.Logger().Warn("Recaptcha validation failed", "ip", c.RealIP())
+			logger.Warn("Postcard submission rejected",
+				"event", "postcard.submission.rejected",
+				"outcome", "captcha_rejected",
+			)
 			utils.SendToastMessage("Captcha verification failed", "error", true, c, "")
 			return utils.BadRequestError(c)
 		}
 	} else {
-		app.Logger().Warn("Captcha verification is disabled for the local or test environment")
+		logger.Warn("Postcard captcha verification skipped",
+			"event", "postcard.captcha.skipped",
+			"outcome", "disabled",
+		)
 	}
 
 	collection, err := app.FindCollectionByNameOrId(constants.CollectionPostcards)
 	if err != nil {
-		app.Logger().Error("Failed to find postcard collection", "error", err.Error())
+		logger.Error("Postcard collection lookup failed",
+			"event", "postcard.submission.failed",
+			"outcome", "collection_unavailable",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return utils.NotFoundError(c)
 	}
 
@@ -83,9 +111,19 @@ func savePostcard(app *pocketbase.PocketBase, c *core.RequestEvent, p *bluemonda
 	record.Set("notify_sender", postData.NotificationRequired)
 
 	if err := app.Save(record); err != nil {
-
+		logger.Error("Postcard submission persistence failed",
+			"event", "postcard.submission.failed",
+			"outcome", "persistence_error",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return renderForm(postData.ImageId, app, c, captcha)
 	}
+
+	logger.Info("Postcard submission queued",
+		"event", "postcard.submission.queued",
+		"outcome", "queued",
+	)
 
 	utils.SendToastMessage("Thank you! Your postcard has been queued for sending!", "success", true, c, "")
 

--- a/internal/handlers/postcards/save_test.go
+++ b/internal/handlers/postcards/save_test.go
@@ -1,9 +1,7 @@
 package postcards
 
 import (
-	"context"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,16 +10,15 @@ import (
 
 	"github.com/blackfyre/wga/internal/config"
 	"github.com/blackfyre/wga/internal/logging"
+	"github.com/blackfyre/wga/internal/testutils"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tests"
-	"github.com/pocketbase/pocketbase/tools/logger"
 	"github.com/pocketbase/pocketbase/tools/router"
 )
 
 func TestSavePostcardDoesNotLogSubmittedForm(t *testing.T) {
-	app := newPostcardLoggingTestApp(t)
-	captured := capturePostcardLogs(app)
+	app := testutils.NewTestApp(t)
+	captured := testutils.CaptureLogs(app)
 	form := url.Values{
 		"sender_name":          {"sender-name-value"},
 		"sender_email":         {"sender@example.test"},
@@ -44,8 +41,8 @@ func TestSavePostcardDoesNotLogSubmittedForm(t *testing.T) {
 
 	_ = savePostcard(app, event, bluemonday.NewPolicy(), config.Captcha{})
 
-	flushPostcardLogs(t, app)
-	entry := postcardLogWithEvent(captured(), "postcard.submission.rejected")
+	testutils.FlushLogs(t, app)
+	entry := testutils.LogWithEvent(captured(), "postcard.submission.rejected")
 	if entry == nil {
 		t.Fatal("expected a postcard rejection log")
 	}
@@ -56,7 +53,7 @@ func TestSavePostcardDoesNotLogSubmittedForm(t *testing.T) {
 		t.Fatalf("outcome = %v, want %q", got, "honeypot")
 	}
 
-	output := fmt.Sprint(postcardLogData(captured()))
+	output := fmt.Sprint(testutils.LogData(captured()))
 	for _, sensitive := range []string{
 		"sender-name-value",
 		"sender@example.test",
@@ -69,66 +66,4 @@ func TestSavePostcardDoesNotLogSubmittedForm(t *testing.T) {
 			t.Fatalf("captured log contains %q: %s", sensitive, output)
 		}
 	}
-}
-
-func newPostcardLoggingTestApp(t *testing.T) *tests.TestApp {
-	t.Helper()
-
-	app, err := tests.NewTestApp()
-	if err != nil {
-		t.Fatalf("create test app: %v", err)
-	}
-	t.Cleanup(app.Cleanup)
-	app.Settings().Logs.MaxDays = 1
-
-	return app
-}
-
-func capturePostcardLogs(app *tests.TestApp) func() []*core.Log {
-	var captured []*core.Log
-	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
-		log, ok := e.Model.(*core.Log)
-		if ok {
-			entry := *log
-			entry.Data = maps.Clone(log.Data)
-			captured = append(captured, &entry)
-		}
-
-		return e.Next()
-	})
-
-	return func() []*core.Log {
-		return captured
-	}
-}
-
-func flushPostcardLogs(t *testing.T, app *tests.TestApp) {
-	t.Helper()
-
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	if err := handler.WriteAll(context.Background()); err != nil {
-		t.Fatalf("write logs: %v", err)
-	}
-}
-
-func postcardLogWithEvent(logs []*core.Log, event string) *core.Log {
-	for _, entry := range logs {
-		if entry.Data["event"] == event {
-			return entry
-		}
-	}
-
-	return nil
-}
-
-func postcardLogData(logs []*core.Log) []any {
-	data := make([]any, len(logs))
-	for index, entry := range logs {
-		data[index] = entry.Data
-	}
-
-	return data
 }

--- a/internal/handlers/postcards/save_test.go
+++ b/internal/handlers/postcards/save_test.go
@@ -1,0 +1,134 @@
+package postcards
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/blackfyre/wga/internal/config"
+	"github.com/blackfyre/wga/internal/logging"
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
+	"github.com/pocketbase/pocketbase/tools/router"
+)
+
+func TestSavePostcardDoesNotLogSubmittedForm(t *testing.T) {
+	app := newPostcardLoggingTestApp(t)
+	captured := capturePostcardLogs(app)
+	form := url.Values{
+		"sender_name":          {"sender-name-value"},
+		"sender_email":         {"sender@example.test"},
+		"recipients[]":         {"recipient@example.test"},
+		"message":              {"message-body-value"},
+		"image_id":             {"image-id"},
+		"g-recaptcha-response": {"captcha-token-value"},
+		"name":                 {"honeypot-name-value"},
+	}
+	request := httptest.NewRequest(http.MethodPost, "/postcard", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	event := &core.RequestEvent{
+		App: app,
+		Event: router.Event{
+			Request:  request,
+			Response: httptest.NewRecorder(),
+		},
+	}
+	logging.SetRequestID(event, "request-123")
+
+	_ = savePostcard(app, event, bluemonday.NewPolicy(), config.Captcha{})
+
+	flushPostcardLogs(t, app)
+	entry := postcardLogWithEvent(captured(), "postcard.submission.rejected")
+	if entry == nil {
+		t.Fatal("expected a postcard rejection log")
+	}
+	if got := entry.Data["request_id"]; got != "request-123" {
+		t.Fatalf("request_id = %v, want %q", got, "request-123")
+	}
+	if got := entry.Data["outcome"]; got != "honeypot" {
+		t.Fatalf("outcome = %v, want %q", got, "honeypot")
+	}
+
+	output := fmt.Sprint(postcardLogData(captured()))
+	for _, sensitive := range []string{
+		"sender-name-value",
+		"sender@example.test",
+		"recipient@example.test",
+		"message-body-value",
+		"captcha-token-value",
+		"honeypot-name-value",
+	} {
+		if strings.Contains(output, sensitive) {
+			t.Fatalf("captured log contains %q: %s", sensitive, output)
+		}
+	}
+}
+
+func newPostcardLoggingTestApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	app.Settings().Logs.MaxDays = 1
+
+	return app
+}
+
+func capturePostcardLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+func flushPostcardLogs(t *testing.T, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+func postcardLogWithEvent(logs []*core.Log, event string) *core.Log {
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+func postcardLogData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
+}

--- a/internal/handlers/postcards/send.go
+++ b/internal/handlers/postcards/send.go
@@ -4,37 +4,44 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/blackfyre/wga/internal/assets/templ/components"
 	"github.com/blackfyre/wga/internal/config"
 	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func sendPostcard(app *pocketbase.PocketBase, c *core.RequestEvent, captcha config.Captcha) error {
-
+func sendPostcard(app core.App, c *core.RequestEvent, captcha config.Captcha) error {
 	artworkId := cmp.Or(c.Request.URL.Query().Get("awid"), "")
 
 	if artworkId == "" {
-		app.Logger().Error("No artwork id provided for postcard", "ip", c.RealIP())
+		logging.RequestLogger(app, c).Warn("Postcard form request rejected",
+			"event", "postcard.form.rejected",
+			"outcome", "missing_artwork_id",
+		)
 		return utils.BadRequestError(c)
 	}
 
 	return renderForm(artworkId, app, c, captcha)
 }
 
-func renderForm(artworkId string, app *pocketbase.PocketBase, c *core.RequestEvent, captcha config.Captcha) error {
+func renderForm(artworkId string, app core.App, c *core.RequestEvent, captcha config.Captcha) error {
 	ctx := context.Background()
+	logger := logging.RequestLogger(app, c)
 
 	r, err := app.FindRecordById(constants.CollectionArtworks, artworkId)
 
 	if err != nil {
-		app.Logger().Error("Failed to find artwork "+artworkId, "error", err.Error())
+		logger.Error("Postcard form artwork lookup failed",
+			"event", "postcard.form.failed",
+			"outcome", "artwork_not_found",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return utils.NotFoundError(c)
 	}
 
@@ -55,7 +62,13 @@ func renderForm(artworkId string, app *pocketbase.PocketBase, c *core.RequestEve
 	err = components.PostcardEditor(editor).Render(ctx, &buf)
 
 	if err != nil {
-		app.Logger().Error(fmt.Sprintf("Failed to render the postcard editor with image_id %s", artworkId), "error", err.Error())
+		logger.Error("Postcard form rendering failed",
+			"event", "postcard.form.failed",
+			"artwork_id", r.Id,
+			"outcome", "render_error",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return utils.ServerFaultError(c)
 	}
 

--- a/internal/handlers/postcards/view.go
+++ b/internal/handlers/postcards/view.go
@@ -4,36 +4,48 @@ import (
 	"bytes"
 	"cmp"
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
 	tmplUtils "github.com/blackfyre/wga/internal/assets/templ/utils"
 	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func viewPostcard(app *pocketbase.PocketBase, c *core.RequestEvent) error {
+func viewPostcard(app core.App, c *core.RequestEvent) error {
 	// postCardId := c.QueryParamDefault("p", "nope")
 	postCardId := cmp.Or(c.Request.URL.Query().Get("p"), "nope")
+	logger := logging.RequestLogger(app, c)
 
 	if postCardId == "nope" {
-		app.Logger().Error(fmt.Sprintf("Invalid postcard id: %s", postCardId))
+		logger.Warn("Postcard view rejected",
+			"event", "postcard.view.rejected",
+			"outcome", "missing_postcard_id",
+		)
 		return utils.NotFoundError(c)
 	}
 
 	r, err := app.FindRecordById(constants.CollectionPostcards, postCardId)
 
 	if err != nil {
-		app.Logger().Error("Failed to find postcard", "id", postCardId, "error", err.Error())
+		logger.Error("Postcard view lookup failed",
+			"event", "postcard.view.failed",
+			"outcome", "postcard_not_found",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return utils.NotFoundError(c)
 	}
 
 	if errs := app.ExpandRecord(r, []string{"image_id"}, nil); len(errs) > 0 {
-		app.Logger().Error("Failed to expand record", "id", postCardId, "errors", errs)
+		logger.Error("Postcard view expansion failed",
+			"event", "postcard.view.failed",
+			"outcome", "expansion_error",
+			"error", logging.Redact(errs),
+		)
 		return utils.ServerFaultError(c)
 	}
 
@@ -57,7 +69,12 @@ func viewPostcard(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	err = pages.PostcardPage(content).Render(ctx, &buf)
 
 	if err != nil {
-		app.Logger().Error("Error rendering artwork page", "error", err.Error())
+		logger.Error("Postcard view rendering failed",
+			"event", "postcard.view.failed",
+			"outcome", "render_error",
+			"error_type", logging.ErrorType(err),
+			"error", logging.Redact(err),
+		)
 		return utils.ServerFaultError(c)
 	}
 

--- a/internal/handlers/postcards/view.go
+++ b/internal/handlers/postcards/view.go
@@ -16,7 +16,6 @@ import (
 )
 
 func viewPostcard(app core.App, c *core.RequestEvent) error {
-	// postCardId := c.QueryParamDefault("p", "nope")
 	postCardId := cmp.Or(c.Request.URL.Query().Get("p"), "nope")
 	logger := logging.RequestLogger(app, c)
 

--- a/internal/hooks/files.go
+++ b/internal/hooks/files.go
@@ -1,21 +1,25 @@
 package hooks
 
 import (
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/pocketbase/pocketbase/core"
 )
 
 func fileDownloadHook(app core.App) {
 	app.Logger().Debug("Registering file download hook...")
 	app.OnFileDownloadRequest().BindFunc(func(e *core.FileDownloadRequestEvent) error {
-		// e.App
-		// e.Collection
-		// e.Record
-		// e.FileField
-		// e.ServedPath
-		// e.ServedName
-		// and all RequestEvent fields...
-		app.Logger().Debug("File download request", "event", e)
+		logFileDownload(app, e)
 
 		return e.Next()
 	})
+}
+
+func logFileDownload(app core.App, e *core.FileDownloadRequestEvent) {
+	logging.RequestLogger(app, e.RequestEvent).Debug("File download served",
+		"event", "file.download.served",
+		"collection", e.Record.Collection().Name,
+		"record_id", e.Record.Id,
+		"file_field", e.FileField.Name,
+		"outcome", "served",
+	)
 }

--- a/internal/hooks/files_test.go
+++ b/internal/hooks/files_test.go
@@ -1,25 +1,28 @@
 package hooks
 
 import (
-	"context"
 	"fmt"
 	"log/slog"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/blackfyre/wga/internal/logging"
+	"github.com/blackfyre/wga/internal/testutils"
 	"github.com/pocketbase/pocketbase/core"
-	"github.com/pocketbase/pocketbase/tests"
 	"github.com/pocketbase/pocketbase/tools/logger"
 	"github.com/pocketbase/pocketbase/tools/router"
 )
 
 func TestLogFileDownloadExcludesRequestEvent(t *testing.T) {
-	app := newHookTestApp(t)
-	captured := captureHookLogs(app)
+	app := testutils.NewTestApp(t)
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	handler.SetLevel(slog.LevelDebug)
+	captured := testutils.CaptureLogs(app)
 	collection := core.NewBaseCollection("artworks")
 	field := &core.FileField{Name: "image"}
 	collection.Fields.Add(field)
@@ -44,8 +47,8 @@ func TestLogFileDownloadExcludesRequestEvent(t *testing.T) {
 		ServedName:   "secret-file-name",
 	})
 
-	flushHookLogs(t, app)
-	entry := hookLogWithEvent(captured(), "file.download.served")
+	testutils.FlushLogs(t, app)
+	entry := testutils.LogWithEvent(captured(), "file.download.served")
 	if entry == nil {
 		t.Fatal("expected a file download log")
 	}
@@ -59,77 +62,10 @@ func TestLogFileDownloadExcludesRequestEvent(t *testing.T) {
 		t.Fatalf("file_field = %v, want %q", got, field.Name)
 	}
 
-	output := fmt.Sprint(hookLogData(captured()))
+	output := fmt.Sprint(testutils.LogData(captured()))
 	for _, sensitive := range []string{"secret-token", "secret-message-body", "secret-served-path", "secret-file-name"} {
 		if strings.Contains(output, sensitive) {
 			t.Fatalf("captured log contains %q: %s", sensitive, output)
 		}
 	}
-}
-
-func newHookTestApp(t *testing.T) *tests.TestApp {
-	t.Helper()
-
-	app, err := tests.NewTestApp()
-	if err != nil {
-		t.Fatalf("create test app: %v", err)
-	}
-	t.Cleanup(app.Cleanup)
-	app.Settings().Logs.MaxDays = 1
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	handler.SetLevel(slog.LevelDebug)
-
-	return app
-}
-
-func captureHookLogs(app *tests.TestApp) func() []*core.Log {
-	var captured []*core.Log
-	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
-		log, ok := e.Model.(*core.Log)
-		if ok {
-			entry := *log
-			entry.Data = maps.Clone(log.Data)
-			captured = append(captured, &entry)
-		}
-
-		return e.Next()
-	})
-
-	return func() []*core.Log {
-		return captured
-	}
-}
-
-func flushHookLogs(t *testing.T, app *tests.TestApp) {
-	t.Helper()
-
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	if err := handler.WriteAll(context.Background()); err != nil {
-		t.Fatalf("write logs: %v", err)
-	}
-}
-
-func hookLogWithEvent(logs []*core.Log, event string) *core.Log {
-	for _, entry := range logs {
-		if entry.Data["event"] == event {
-			return entry
-		}
-	}
-
-	return nil
-}
-
-func hookLogData(logs []*core.Log) []any {
-	data := make([]any, len(logs))
-	for index, entry := range logs {
-		data[index] = entry.Data
-	}
-
-	return data
 }

--- a/internal/hooks/files_test.go
+++ b/internal/hooks/files_test.go
@@ -1,0 +1,135 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/blackfyre/wga/internal/logging"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
+	"github.com/pocketbase/pocketbase/tools/router"
+)
+
+func TestLogFileDownloadExcludesRequestEvent(t *testing.T) {
+	app := newHookTestApp(t)
+	captured := captureHookLogs(app)
+	collection := core.NewBaseCollection("artworks")
+	field := &core.FileField{Name: "image"}
+	collection.Fields.Add(field)
+	record := core.NewRecord(collection)
+	record.Id = "artwork-record"
+	request := httptest.NewRequest(http.MethodGet, "/api/files/artworks/artwork-record/secret-file-name", strings.NewReader("secret-message-body"))
+	request.Header.Set("Authorization", "secret-token")
+	requestEvent := &core.RequestEvent{
+		App: app,
+		Event: router.Event{
+			Request:  request,
+			Response: httptest.NewRecorder(),
+		},
+	}
+	logging.SetRequestID(requestEvent, "request-123")
+
+	logFileDownload(app, &core.FileDownloadRequestEvent{
+		RequestEvent: requestEvent,
+		Record:       record,
+		FileField:    field,
+		ServedPath:   "secret-served-path",
+		ServedName:   "secret-file-name",
+	})
+
+	flushHookLogs(t, app)
+	entry := hookLogWithEvent(captured(), "file.download.served")
+	if entry == nil {
+		t.Fatal("expected a file download log")
+	}
+	if got := entry.Data["request_id"]; got != "request-123" {
+		t.Fatalf("request_id = %v, want %q", got, "request-123")
+	}
+	if got := entry.Data["record_id"]; got != record.Id {
+		t.Fatalf("record_id = %v, want %q", got, record.Id)
+	}
+	if got := entry.Data["file_field"]; got != field.Name {
+		t.Fatalf("file_field = %v, want %q", got, field.Name)
+	}
+
+	output := fmt.Sprint(hookLogData(captured()))
+	for _, sensitive := range []string{"secret-token", "secret-message-body", "secret-served-path", "secret-file-name"} {
+		if strings.Contains(output, sensitive) {
+			t.Fatalf("captured log contains %q: %s", sensitive, output)
+		}
+	}
+}
+
+func newHookTestApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	app.Settings().Logs.MaxDays = 1
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	handler.SetLevel(slog.LevelDebug)
+
+	return app
+}
+
+func captureHookLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+func flushHookLogs(t *testing.T, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+func hookLogWithEvent(logs []*core.Log, event string) *core.Log {
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+func hookLogData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -30,6 +30,7 @@ func RegisterRequestIDMiddleware(app core.App) {
 	})
 }
 
+// AttachRequestID assigns a server-generated identifier without trusting public request headers.
 func AttachRequestID(e *core.RequestEvent) string {
 	requestID := uuid.NewString()
 	SetRequestID(e, requestID)
@@ -77,6 +78,7 @@ func RunLogger(app core.App, runID string) *slog.Logger {
 	return app.Logger().With("run_id", runID)
 }
 
+// Redact intentionally discards all input to prevent sensitive data from reaching logs.
 func Redact(_ any) string {
 	return Redacted
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,90 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+
+	"github.com/google/uuid"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const (
+	RequestIDHeader = "X-Request-ID"
+	Redacted        = "[REDACTED]"
+
+	requestIDKey = "request_id"
+)
+
+type requestIDContextKey struct{}
+
+func RegisterRequestIDMiddleware(app core.App) {
+	app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+		se.Router.BindFunc(func(e *core.RequestEvent) error {
+			AttachRequestID(e)
+
+			return e.Next()
+		})
+
+		return se.Next()
+	})
+}
+
+func AttachRequestID(e *core.RequestEvent) string {
+	requestID := uuid.NewString()
+	SetRequestID(e, requestID)
+
+	return requestID
+}
+
+func SetRequestID(e *core.RequestEvent, requestID string) {
+	e.Set(requestIDKey, requestID)
+	e.Request = e.Request.WithContext(WithRequestID(e.Request.Context(), requestID))
+	e.Response.Header().Set(RequestIDHeader, requestID)
+}
+
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDContextKey{}, requestID)
+}
+
+func RequestID(e *core.RequestEvent) string {
+	if requestID, ok := e.Get(requestIDKey).(string); ok {
+		return requestID
+	}
+
+	return RequestIDFromContext(e.Request.Context())
+}
+
+func RequestIDFromContext(ctx context.Context) string {
+	requestID, _ := ctx.Value(requestIDContextKey{}).(string)
+
+	return requestID
+}
+
+func RequestLogger(app core.App, e *core.RequestEvent) *slog.Logger {
+	return app.Logger().With("request_id", RequestID(e))
+}
+
+func ContextLogger(app core.App, ctx context.Context) *slog.Logger {
+	return app.Logger().With("request_id", RequestIDFromContext(ctx))
+}
+
+func NewRunID() string {
+	return uuid.NewString()
+}
+
+func RunLogger(app core.App, runID string) *slog.Logger {
+	return app.Logger().With("run_id", runID)
+}
+
+func Redact(_ any) string {
+	return Redacted
+}
+
+func ErrorType(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	return reflect.TypeOf(err).String()
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,178 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
+)
+
+func TestRequestIDMiddlewareCorrelatesRequestLogs(t *testing.T) {
+	var captured func() []*core.Log
+
+	scenario := tests.ApiScenario{
+		Name:                  "request ID is retained in the route log",
+		Method:                http.MethodGet,
+		URL:                   "/request-id",
+		ExpectedStatus:        http.StatusNoContent,
+		DisableTestAppCleanup: true,
+		TestAppFactory: func(t testing.TB) *tests.TestApp {
+			app := newTestApp(t)
+			captured = captureLogs(app)
+			RegisterRequestIDMiddleware(app)
+			app.OnServe().BindFunc(func(se *core.ServeEvent) error {
+				se.Router.GET("/request-id", func(e *core.RequestEvent) error {
+					if RequestID(e) != RequestIDFromContext(e.Request.Context()) {
+						return e.InternalServerError("request ID was not propagated", nil)
+					}
+
+					RequestLogger(app, e).Info("Request correlation test", "event", "test.request.started")
+					RequestLogger(app, e).Info("Request correlation test", "event", "test.request.completed")
+
+					return e.NoContent(http.StatusNoContent)
+				})
+
+				return se.Next()
+			})
+
+			return app
+		},
+		AfterTestFunc: func(t testing.TB, app *tests.TestApp, response *http.Response) {
+			requestID := response.Header.Get(RequestIDHeader)
+			if _, err := uuid.Parse(requestID); err != nil {
+				t.Fatalf("response request ID %q is not a UUID: %v", requestID, err)
+			}
+
+			flushLogs(t, app)
+			for _, event := range []string{"test.request.started", "test.request.completed"} {
+				entry := logWithEvent(captured(), event)
+				if entry == nil {
+					t.Fatalf("expected a %q log", event)
+				}
+				if got := entry.Data["request_id"]; got != requestID {
+					t.Fatalf("%s request_id = %v, want %q", event, got, requestID)
+				}
+			}
+		},
+	}
+
+	scenario.Test(t)
+}
+
+func TestRedactKeepsSensitiveValuesOutOfCapturedLogs(t *testing.T) {
+	app := newTestApp(t)
+	captured := captureLogs(app)
+	request := httptest.NewRequest(http.MethodPost, "/postcard", strings.NewReader("message-body-value"))
+	request.Header.Set("Authorization", "credential-value")
+	sensitiveValues := []string{
+		"captcha-token-value",
+		"credential-value",
+		"person@example.test",
+		"message-body-value",
+	}
+
+	for _, value := range sensitiveValues {
+		app.Logger().Info("Redaction test", "event", "test.redaction", "sensitive", Redact(value))
+	}
+	app.Logger().Info("Redaction test", "event", "test.redaction", "request", Redact(request))
+
+	flushLogs(t, app)
+	output := fmt.Sprint(logData(captured()))
+	for _, value := range sensitiveValues {
+		if strings.Contains(output, value) {
+			t.Fatalf("captured log contains %q: %s", value, output)
+		}
+	}
+	if !strings.Contains(output, Redacted) {
+		t.Fatalf("captured log does not contain %q: %s", Redacted, output)
+	}
+}
+
+func TestContextLoggerRetainsRequestID(t *testing.T) {
+	app := newTestApp(t)
+	captured := captureLogs(app)
+
+	ContextLogger(app, WithRequestID(context.Background(), "request-123")).Info(
+		"Context correlation test",
+		"event", "test.context",
+	)
+
+	flushLogs(t, app)
+	entry := logWithEvent(captured(), "test.context")
+	if entry == nil {
+		t.Fatal("expected a context correlation log")
+	}
+	if got := entry.Data["request_id"]; got != "request-123" {
+		t.Fatalf("request_id = %v, want %q", got, "request-123")
+	}
+}
+
+func newTestApp(t testing.TB) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	app.Settings().Logs.MaxDays = 1
+
+	return app
+}
+
+func captureLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+func flushLogs(t testing.TB, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+func logWithEvent(logs []*core.Log, event string) *core.Log {
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+func logData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -3,16 +3,15 @@ package logging
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/blackfyre/wga/internal/testutils"
 	"github.com/google/uuid"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/tests"
-	"github.com/pocketbase/pocketbase/tools/logger"
 )
 
 func TestRequestIDMiddlewareCorrelatesRequestLogs(t *testing.T) {
@@ -22,11 +21,12 @@ func TestRequestIDMiddlewareCorrelatesRequestLogs(t *testing.T) {
 		Name:                  "request ID is retained in the route log",
 		Method:                http.MethodGet,
 		URL:                   "/request-id",
+		Headers:               map[string]string{RequestIDHeader: "client-supplied"},
 		ExpectedStatus:        http.StatusNoContent,
 		DisableTestAppCleanup: true,
 		TestAppFactory: func(t testing.TB) *tests.TestApp {
-			app := newTestApp(t)
-			captured = captureLogs(app)
+			app := testutils.NewTestApp(t)
+			captured = testutils.CaptureLogs(app)
 			RegisterRequestIDMiddleware(app)
 			app.OnServe().BindFunc(func(se *core.ServeEvent) error {
 				se.Router.GET("/request-id", func(e *core.RequestEvent) error {
@@ -47,13 +47,16 @@ func TestRequestIDMiddlewareCorrelatesRequestLogs(t *testing.T) {
 		},
 		AfterTestFunc: func(t testing.TB, app *tests.TestApp, response *http.Response) {
 			requestID := response.Header.Get(RequestIDHeader)
+			if requestID == "client-supplied" {
+				t.Fatal("response reused a client-supplied request ID")
+			}
 			if _, err := uuid.Parse(requestID); err != nil {
 				t.Fatalf("response request ID %q is not a UUID: %v", requestID, err)
 			}
 
-			flushLogs(t, app)
+			testutils.FlushLogs(t, app)
 			for _, event := range []string{"test.request.started", "test.request.completed"} {
-				entry := logWithEvent(captured(), event)
+				entry := testutils.LogWithEvent(captured(), event)
 				if entry == nil {
 					t.Fatalf("expected a %q log", event)
 				}
@@ -68,8 +71,8 @@ func TestRequestIDMiddlewareCorrelatesRequestLogs(t *testing.T) {
 }
 
 func TestRedactKeepsSensitiveValuesOutOfCapturedLogs(t *testing.T) {
-	app := newTestApp(t)
-	captured := captureLogs(app)
+	app := testutils.NewTestApp(t)
+	captured := testutils.CaptureLogs(app)
 	request := httptest.NewRequest(http.MethodPost, "/postcard", strings.NewReader("message-body-value"))
 	request.Header.Set("Authorization", "credential-value")
 	sensitiveValues := []string{
@@ -84,8 +87,8 @@ func TestRedactKeepsSensitiveValuesOutOfCapturedLogs(t *testing.T) {
 	}
 	app.Logger().Info("Redaction test", "event", "test.redaction", "request", Redact(request))
 
-	flushLogs(t, app)
-	output := fmt.Sprint(logData(captured()))
+	testutils.FlushLogs(t, app)
+	output := fmt.Sprint(testutils.LogData(captured()))
 	for _, value := range sensitiveValues {
 		if strings.Contains(output, value) {
 			t.Fatalf("captured log contains %q: %s", value, output)
@@ -97,82 +100,20 @@ func TestRedactKeepsSensitiveValuesOutOfCapturedLogs(t *testing.T) {
 }
 
 func TestContextLoggerRetainsRequestID(t *testing.T) {
-	app := newTestApp(t)
-	captured := captureLogs(app)
+	app := testutils.NewTestApp(t)
+	captured := testutils.CaptureLogs(app)
 
 	ContextLogger(app, WithRequestID(context.Background(), "request-123")).Info(
 		"Context correlation test",
 		"event", "test.context",
 	)
 
-	flushLogs(t, app)
-	entry := logWithEvent(captured(), "test.context")
+	testutils.FlushLogs(t, app)
+	entry := testutils.LogWithEvent(captured(), "test.context")
 	if entry == nil {
 		t.Fatal("expected a context correlation log")
 	}
 	if got := entry.Data["request_id"]; got != "request-123" {
 		t.Fatalf("request_id = %v, want %q", got, "request-123")
 	}
-}
-
-func newTestApp(t testing.TB) *tests.TestApp {
-	t.Helper()
-
-	app, err := tests.NewTestApp()
-	if err != nil {
-		t.Fatalf("create test app: %v", err)
-	}
-	t.Cleanup(app.Cleanup)
-	app.Settings().Logs.MaxDays = 1
-
-	return app
-}
-
-func captureLogs(app *tests.TestApp) func() []*core.Log {
-	var captured []*core.Log
-	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
-		log, ok := e.Model.(*core.Log)
-		if ok {
-			entry := *log
-			entry.Data = maps.Clone(log.Data)
-			captured = append(captured, &entry)
-		}
-
-		return e.Next()
-	})
-
-	return func() []*core.Log {
-		return captured
-	}
-}
-
-func flushLogs(t testing.TB, app *tests.TestApp) {
-	t.Helper()
-
-	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
-	if !ok {
-		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
-	}
-	if err := handler.WriteAll(context.Background()); err != nil {
-		t.Fatalf("write logs: %v", err)
-	}
-}
-
-func logWithEvent(logs []*core.Log, event string) *core.Log {
-	for _, entry := range logs {
-		if entry.Data["event"] == event {
-			return entry
-		}
-	}
-
-	return nil
-}
-
-func logData(logs []*core.Log) []any {
-	data := make([]any, len(logs))
-	for index, entry := range logs {
-		data[index] = entry.Data
-	}
-
-	return data
 }

--- a/internal/repositories/contributors.go
+++ b/internal/repositories/contributors.go
@@ -79,6 +79,9 @@ func (r *ContributorsRepository) GetContributorsWithSource(ctx context.Context) 
 		utils.SetCachedValue(r.app, r.cacheKey, contributors, r.cacheTTL)
 		return contributors, ContributorsSourceAPI, nil
 	}
+	if ctx.Err() != nil {
+		return nil, "", ctx.Err()
+	}
 
 	logging.ContextLogger(r.app, ctx).Warn("Contributors API fetch failed; trying local fallback",
 		"event", "contributors.fetch.fallback",

--- a/internal/repositories/contributors.go
+++ b/internal/repositories/contributors.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
+	"github.com/blackfyre/wga/internal/logging"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/pocketbase/pocketbase"
 )
@@ -59,16 +61,16 @@ func newContributorsRepositoryWithConfig(app *pocketbase.PocketBase, client *htt
 }
 
 func (r *ContributorsRepository) GetContributors() ([]pages.GithubContributor, error) {
-	contributors, _, err := r.GetContributorsWithSource()
+	contributors, _, err := r.GetContributorsWithSource(context.Background())
 	return contributors, err
 }
 
-func (r *ContributorsRepository) GetContributorsWithSource() ([]pages.GithubContributor, ContributorsSource, error) {
+func (r *ContributorsRepository) GetContributorsWithSource(ctx context.Context) ([]pages.GithubContributor, ContributorsSource, error) {
 	if cached, ok := utils.GetCachedValue[[]pages.GithubContributor](r.app, r.cacheKey); ok {
 		return cached, ContributorsSourceCache, nil
 	}
 
-	contributors, err := r.fetchContributorsFromAPI()
+	contributors, err := r.fetchContributorsFromAPI(ctx)
 	if err == nil {
 		if err := r.persistContributors(contributors); err != nil {
 			return nil, "", err
@@ -78,7 +80,12 @@ func (r *ContributorsRepository) GetContributorsWithSource() ([]pages.GithubCont
 		return contributors, ContributorsSourceAPI, nil
 	}
 
-	r.app.Logger().Warn("Contributors API fetch failed; trying local fallback", "error", err)
+	logging.ContextLogger(r.app, ctx).Warn("Contributors API fetch failed; trying local fallback",
+		"event", "contributors.fetch.fallback",
+		"outcome", "fallback",
+		"error_type", logging.ErrorType(err),
+		"error", logging.Redact(err),
+	)
 
 	fallbackContributors, fallbackErr := r.readStoredContributors()
 	if fallbackErr != nil {
@@ -90,8 +97,8 @@ func (r *ContributorsRepository) GetContributorsWithSource() ([]pages.GithubCont
 	return fallbackContributors, ContributorsSourceFileFallback, nil
 }
 
-func (r *ContributorsRepository) fetchContributorsFromAPI() ([]pages.GithubContributor, error) {
-	req, err := http.NewRequest(http.MethodGet, r.apiURL, nil)
+func (r *ContributorsRepository) fetchContributorsFromAPI(ctx context.Context) ([]pages.GithubContributor, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.apiURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/contributors_test.go
+++ b/internal/repositories/contributors_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -121,4 +122,52 @@ func TestContributorsRepositoryGetContributors(t *testing.T) {
 			t.Fatalf("expected fallback contributor result, got %+v", contributors)
 		}
 	})
+}
+
+func TestFetchContributorsFromAPIHonoursCancellation(t *testing.T) {
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	defer ts.Close()
+
+	repo := newContributorsRepositoryWithConfig(
+		pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"}),
+		ts.Client(),
+		ts.URL,
+		filepath.Join(t.TempDir(), "contributors.json"),
+		"contributors:test:cancellation",
+		time.Hour,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := repo.fetchContributorsFromAPI(ctx)
+		result <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("contributors request did not reach the upstream server")
+	}
+	cancel()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("upstream request context was not cancelled")
+	}
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("fetch error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("contributors request did not return after cancellation")
+	}
 }

--- a/internal/repositories/contributors_test.go
+++ b/internal/repositories/contributors_test.go
@@ -171,3 +171,73 @@ func TestFetchContributorsFromAPIHonoursCancellation(t *testing.T) {
 		t.Fatal("contributors request did not return after cancellation")
 	}
 }
+
+func TestContributorsRepositoryDoesNotCacheFallbackAfterCancellation(t *testing.T) {
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+	cacheKey := "contributors:test:cancelled-request"
+	cacheFile := filepath.Join(t.TempDir(), "contributors.json")
+	fallbackContributors := []pages.GithubContributor{{Login: "file-user", Contributions: 5}}
+	file, err := os.Create(cacheFile)
+	if err != nil {
+		t.Fatalf("failed to create fallback file: %v", err)
+	}
+	if err := json.NewEncoder(file).Encode(fallbackContributors); err != nil {
+		_ = file.Close()
+		t.Fatalf("failed to write fallback file: %v", err)
+	}
+	_ = file.Close()
+
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+		close(cancelled)
+	}))
+	defer ts.Close()
+
+	repo := newContributorsRepositoryWithConfig(app, ts.Client(), ts.URL, cacheFile, cacheKey, time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type contributorsResult struct {
+		contributors []pages.GithubContributor
+		source       ContributorsSource
+		err          error
+	}
+	result := make(chan contributorsResult, 1)
+	go func() {
+		contributors, source, err := repo.GetContributorsWithSource(ctx)
+		result <- contributorsResult{contributors: contributors, source: source, err: err}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("contributors request did not reach the upstream server")
+	}
+	cancel()
+
+	select {
+	case result := <-result:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("contributors error = %v, want context cancellation", result.err)
+		}
+		if result.contributors != nil {
+			t.Fatalf("contributors = %+v, want nil", result.contributors)
+		}
+		if result.source != "" {
+			t.Fatalf("source = %q, want empty", result.source)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("contributors request did not return after cancellation")
+	}
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("upstream request context was not cancelled")
+	}
+
+	if _, ok := utils.GetCachedValue[[]pages.GithubContributor](app, cacheKey); ok {
+		t.Fatal("cancelled request cached fallback contributors")
+	}
+}

--- a/internal/repositories/contributors_test.go
+++ b/internal/repositories/contributors_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +31,7 @@ func TestContributorsRepositoryGetContributors(t *testing.T) {
 			time.Hour,
 		)
 
-		contributors, source, err := repo.GetContributorsWithSource()
+		contributors, source, err := repo.GetContributorsWithSource(context.Background())
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -64,7 +65,7 @@ func TestContributorsRepositoryGetContributors(t *testing.T) {
 			time.Hour,
 		)
 
-		contributors, source, err := repo.GetContributorsWithSource()
+		contributors, source, err := repo.GetContributorsWithSource(context.Background())
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -107,7 +108,7 @@ func TestContributorsRepositoryGetContributors(t *testing.T) {
 			time.Hour,
 		)
 
-		contributors, source, err := repo.GetContributorsWithSource()
+		contributors, source, err := repo.GetContributorsWithSource(context.Background())
 		if err != nil {
 			t.Fatalf("expected fallback to succeed, got %v", err)
 		}

--- a/internal/testutils/logs.go
+++ b/internal/testutils/logs.go
@@ -1,0 +1,90 @@
+package testutils
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/logger"
+)
+
+// NewTestApp creates a test application that persists captured logs.
+func NewTestApp(t testing.TB) *tests.TestApp {
+	t.Helper()
+
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+	app.Settings().Logs.MaxDays = 1
+
+	return app
+}
+
+// CaptureLogs returns the logs persisted after the helper is registered.
+func CaptureLogs(app *tests.TestApp) func() []*core.Log {
+	var captured []*core.Log
+	app.OnModelCreate(core.LogsTableName).BindFunc(func(e *core.ModelEvent) error {
+		log, ok := e.Model.(*core.Log)
+		if ok {
+			entry := *log
+			entry.Data = maps.Clone(log.Data)
+			captured = append(captured, &entry)
+		}
+
+		return e.Next()
+	})
+
+	return func() []*core.Log {
+		return captured
+	}
+}
+
+// FlushLogs persists logs queued by PocketBase's batch handler.
+func FlushLogs(t testing.TB, app *tests.TestApp) {
+	t.Helper()
+
+	handler, ok := app.Logger().Handler().(*logger.BatchHandler)
+	if !ok {
+		t.Fatalf("expected BatchHandler, got %T", app.Logger().Handler())
+	}
+	if err := handler.WriteAll(context.Background()); err != nil {
+		t.Fatalf("write logs: %v", err)
+	}
+}
+
+// LogWithEvent returns the first captured log with the supplied event field.
+func LogWithEvent(logs []*core.Log, event string) *core.Log {
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			return entry
+		}
+	}
+
+	return nil
+}
+
+// LogsWithEvent returns all captured logs with the supplied event field.
+func LogsWithEvent(logs []*core.Log, event string) []*core.Log {
+	entries := []*core.Log{}
+	for _, entry := range logs {
+		if entry.Data["event"] == event {
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries
+}
+
+// LogData returns all captured log data maps for redaction assertions.
+func LogData(logs []*core.Log) []any {
+	data := make([]any, len(logs))
+	for index, entry := range logs {
+		data[index] = entry.Data
+	}
+
+	return data
+}


### PR DESCRIPTION
## Summary

- add request and cron-run correlation IDs to structured application logs
- redact postcard, contributor, and file-download diagnostics while returning a client-safe contributor error
- keep failed postcard deliveries queued and add captured-log regression coverage

Closes #177

## Validation

- `go mod tidy -diff`
- `go vet ./...`
- `go test ./internal/logging ./internal/handlers/postcards ./internal/handlers/contributors ./internal/repositories ./internal/hooks ./internal/crontab`
- `go test ./... -cover` remains blocked by the unrelated SMTP-port fixture mismatch in `TestConfigurationParsesTypedValues` (expected 1025, got 1525).