### PR TITLE
feat: reinstate CookieConsent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "postcss-nesting": "^13.0.2",
         "tailwindcss": "^4.2.1",
         "trix": "^2.1.16",
+        "vanilla-cookieconsent": "3.1.0",
         "viewerjs": "^1.11.7",
       },
     },
@@ -580,6 +581,8 @@
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vanilla-cookieconsent": ["vanilla-cookieconsent@3.1.0", "", {}, "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA=="],
 
     "viewerjs": ["viewerjs@1.11.7", "", {}, "sha512-0JuVqOmL5v1jmEAlG5EBDR3XquxY8DWFQbFMprOXgaBB0F7Q/X9xWdEaQc59D8xzwkdUgXEMSSknTpriq95igg=="],
 

--- a/internal/assets/templ/components/footer.templ
+++ b/internal/assets/templ/components/footer.templ
@@ -43,7 +43,7 @@ templ Footer() {
 				our <a href="/contributors" hx-get="/contributors">code contributors</a>!
 			</p>
 			<p>
-				<a data-cc="c-settings" href="#">Manage cookie settings</a>
+				<a data-cc="show-preferencesModal" href="#">Manage cookie settings</a>
 			</p>
 		</div>
 		// <nav>

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "postcss-nesting": "^13.0.2",
     "tailwindcss": "^4.2.1",
     "trix": "^2.1.16",
+    "vanilla-cookieconsent": "3.1.0",
     "viewerjs": "^1.11.7"
   },
   "lint-staged": {

--- a/playwright-tests/cookieconsent.spec.ts
+++ b/playwright-tests/cookieconsent.spec.ts
@@ -11,6 +11,9 @@ test("allows visitors to reopen cookie preferences", async ({ page }) => {
 	await consentModal
 		.getByRole("button", { name: "Accept essential cookies" })
 		.click();
+	await expect(consentModal).toBeHidden();
+	await page.reload();
+	await expect(consentModal).toBeHidden();
 
 	await page.getByRole("link", { name: "Manage cookie settings" }).click();
 	await expect(page.locator("#cc-main .pm")).toBeVisible();

--- a/playwright-tests/cookieconsent.spec.ts
+++ b/playwright-tests/cookieconsent.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "@playwright/test";
+
+test("allows visitors to reopen cookie preferences", async ({ page }) => {
+	await page.addInitScript(() => {
+		Object.defineProperty(navigator, "webdriver", { get: () => false });
+	});
+	await page.goto("/");
+
+	const consentModal = page.locator("#cc-main .cm");
+	await expect(consentModal).toBeVisible();
+	await consentModal
+		.getByRole("button", { name: "Accept essential cookies" })
+		.click();
+
+	await page.getByRole("link", { name: "Manage cookie settings" }).click();
+	await expect(page.locator("#cc-main .pm")).toBeVisible();
+});

--- a/resources/css/style.pcss
+++ b/resources/css/style.pcss
@@ -3,6 +3,7 @@
 @import "animate.css";
 @import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Lexend:wght@100..900&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&display=swap");
 @import "../../node_modules/trix/dist/trix.css";
+@import "../../node_modules/vanilla-cookieconsent/dist/cookieconsent.css";
 @import "../../node_modules/viewerjs/dist/viewer.css";
 @source "../../internal/assets/templ";
 @source "../../resources/js";

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -3,6 +3,7 @@ import Viewer from "viewerjs";
 import "htmx.org";
 import htmx from "htmx.org";
 import warningSign from "../assets/warning-sign.svg";
+import { initCookieConsent } from "./cookieconsent";
 import logger from "./logger";
 import { initStatisticsChart } from "./statistics";
 
@@ -876,6 +877,7 @@ const wgaInternal: wgaInternals = {
 
 (() => {
 	logger.debug("Initializing WGA");
+	initCookieConsent();
 	initThemeToggle();
 	wgaInternal.func.init();
 })();

--- a/resources/js/cookieconsent.ts
+++ b/resources/js/cookieconsent.ts
@@ -1,0 +1,50 @@
+import * as CookieConsent from "vanilla-cookieconsent";
+
+export const initCookieConsent = () => {
+	CookieConsent.run({
+		categories: {
+			necessary: {
+				enabled: true,
+				readOnly: true,
+			},
+		},
+		language: {
+			default: "en",
+			translations: {
+				en: {
+					consentModal: {
+						title: "We use cookies",
+						description:
+							'We use essential cookies to make this site work. Read our <a href="/pages/privacy-policy">privacy policy</a>.',
+						acceptNecessaryBtn: "Accept essential cookies",
+						showPreferencesBtn: "Cookie preferences",
+					},
+					preferencesModal: {
+						title: "Cookie preferences",
+						acceptNecessaryBtn: "Accept essential cookies",
+						savePreferencesBtn: "Save preferences",
+						closeIconLabel: "Close cookie preferences",
+						sections: [
+							{
+								title: "Cookie use",
+								description:
+									"We only use essential cookies needed for this site to work.",
+							},
+							{
+								title: "Strictly necessary cookies",
+								description:
+									"These cookies are required for the site to function and cannot be disabled.",
+								linkedCategory: "necessary",
+							},
+							{
+								title: "More information",
+								description:
+									'Read our <a href="/pages/privacy-policy">privacy policy</a>.',
+							},
+						],
+					},
+				},
+			},
+		},
+	});
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,6 +2143,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+vanilla-cookieconsent@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz"
+  integrity sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==
+
 viewerjs@^1.11.7:
   version "1.11.7"
   resolved "https://registry.npmjs.org/viewerjs/-/viewerjs-1.11.7.tgz"


### PR DESCRIPTION
Closes #188

## Summary
- bundle Vanilla CookieConsent 3.1.0 with an essential-cookies-only configuration and privacy-policy links
- restore the footer preferences control using the CookieConsent v3 attribute
- cover accepting and reopening preferences in Playwright

## Verification
- `bun run build`
- `bunx biome check resources/js/app.ts resources/js/cookieconsent.ts playwright-tests/cookieconsent.spec.ts`
- `go vet ./...`
- `bunx playwright test playwright-tests/cookieconsent.spec.ts`
- `bun audit --production` (no vulnerabilities)

### Dependency review
- In-house alternative rejected: consent storage, preference UI, and accessibility are broader than this change should own.
- Source: https://github.com/orestbida/cookieconsent
- Licence: MIT
- Maintainer: Orest Bida
- Transitive production dependencies: 0
- Version pinned: 3.1.0
- Known vulnerabilities at this version: none reported by `bun audit --production`
- Consumers: `resources/js/app.ts`, `resources/css/style.pcss`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cookie consent notice for necessary cookies with an English consent and preferences experience.
  * Included privacy policy and “more information” content in the consent flow.
  * Enabled the “Manage cookie settings” link to reopen the preferences panel.
* **Bug Fixes**
  * Updated the “Manage cookie settings” link behavior to reliably show the preferences panel.
* **Tests**
  * Added Playwright coverage to verify cookie preferences can be reopened after consent and remain hidden until explicitly opened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->