### PR TITLE
perf: improve public catalogue performance

### DIFF
--- a/internal/handlers/artworks/cancellation_test.go
+++ b/internal/handlers/artworks/cancellation_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/blackfyre/wga/internal/requestprotection"
@@ -69,6 +70,44 @@ func TestArtworkSearchResultsWorkflowChecksCancellationBeforeProjection(t *testi
 	want := []string{"artworks.search.count", "artworks.search.records", "artworks.search.projection"}
 	if !reflect.DeepEqual(stages, want) {
 		t.Fatalf("started stages = %v, want %v", stages, want)
+	}
+}
+
+func TestArtworkSearchResultsHandlerSkipsFacetStages(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "artistresult001", "Result Artist")
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id:        "workresult00001",
+		title:     "Result Work",
+		authors:   []string{"artistresult001"},
+		published: true,
+	})
+	request := httptest.NewRequest(http.MethodGet, "/artworks/results?q=Result", nil)
+	request.Header.Set("HX-Request", "true")
+	recorder := httptest.NewRecorder()
+	event := &core.RequestEvent{Event: router.Event{Request: request, Response: recorder}}
+	stages := []string{}
+	checkpoint := func(_ context.Context, stage string) error {
+		stages = append(stages, stage)
+		return nil
+	}
+
+	if err := searchWithCheckpoint(app, event, checkpoint); err != nil {
+		t.Fatalf("searchWithCheckpoint() error = %v", err)
+	}
+	want := []string{"artworks.search.count", "artworks.search.records", "artworks.search.projection"}
+	if !reflect.DeepEqual(stages, want) {
+		t.Fatalf("started stages = %v, want only result stages %v", stages, want)
+	}
+	body := recorder.Body.String()
+	if !strings.Contains(body, `id="artwork-search-results"`) || !strings.Contains(body, "Result Work") {
+		t.Fatalf("results fragment missing expected content: %s", body)
+	}
+	if strings.Contains(body, `id="artwork-filters"`) {
+		t.Fatal("results fragment included filter facets")
+	}
+	if got := recorder.Header().Get("HX-Push-Url"); got != "/artworks/results?q=Result" {
+		t.Fatalf("HX-Push-Url = %q, want results URL", got)
 	}
 }
 

--- a/internal/handlers/artworks/cancellation_test.go
+++ b/internal/handlers/artworks/cancellation_test.go
@@ -51,6 +51,27 @@ func TestArtworkSearchCancellationStopsSubsequentRepositoryStage(t *testing.T) {
 	}
 }
 
+func TestArtworkSearchResultsWorkflowChecksCancellationBeforeProjection(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	stages := []string{}
+	checkpoint := func(ctx context.Context, stage string) error {
+		stages = append(stages, stage)
+		if stage == "artworks.search.projection" {
+			cancel()
+		}
+		return requestprotection.Checkpoint(ctx, stage)
+	}
+
+	if _, err := buildArtworkSearchResultsViewContext(ctx, app, url.Values{}, 1, artworkSearchPageSize, checkpoint); !errors.Is(err, context.Canceled) {
+		t.Fatalf("buildArtworkSearchResultsViewContext() error = %v, want original cancellation cause", err)
+	}
+	want := []string{"artworks.search.count", "artworks.search.records", "artworks.search.projection"}
+	if !reflect.DeepEqual(stages, want) {
+		t.Fatalf("started stages = %v, want %v", stages, want)
+	}
+}
+
 func TestArtworkSearchCancellationSkipsRender(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/handlers/artworks/collection_holdings_cache_test.go
+++ b/internal/handlers/artworks/collection_holdings_cache_test.go
@@ -1,0 +1,104 @@
+package artworks
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase"
+)
+
+func TestCollectionHoldingsColdLoadIsSharedAcrossVenueQueries(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "cacheartist0001", "Cache Artist")
+	saveSearchLocation(t, app, "cachelocation01", "Cache Museum")
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id:        "cacheartwork001",
+		title:     "Cached Work",
+		authors:   []string{"cacheartist0001"},
+		location:  "cachelocation01",
+		published: true,
+	})
+
+	queryCount, err := countCollectionHoldingQueries(app, func() error {
+		const callers = 16
+		start := make(chan struct{})
+		errs := make(chan error, callers)
+		var group sync.WaitGroup
+		group.Add(callers)
+		for i := 0; i < callers; i++ {
+			go func(index int) {
+				defer group.Done()
+				<-start
+				view, _, loadErr := buildArtworkSearchView(app, url.Values{
+					"venue_q": {fmt.Sprintf("museum-%d", index)},
+				}, 1, 16)
+				if loadErr != nil {
+					errs <- loadErr
+					return
+				}
+				if len(view.Facets.Collection.Options) != 0 {
+					errs <- fmt.Errorf("query %d options = %#v, want no name match", index, view.Facets.Collection.Options)
+				}
+			}(i)
+		}
+		close(start)
+		group.Wait()
+		close(errs)
+		for loadErr := range errs {
+			if loadErr != nil {
+				return loadErr
+			}
+		}
+
+		for i := 0; i < 100; i++ {
+			if _, loadErr := getVenueOptions(app, fmt.Sprintf("subsequent-%d", i), ""); loadErr != nil {
+				return loadErr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("load venue options: %v", err)
+	}
+	if queryCount != 1 {
+		t.Fatalf("collection projection query count = %d, want one shared load across arbitrary venue queries", queryCount)
+	}
+}
+
+func countCollectionHoldingQueries(app *pocketbase.PocketBase, fn func() error) (int, error) {
+	concurrent, ok := app.ConcurrentDB().(*dbx.DB)
+	if !ok {
+		return 0, fmt.Errorf("ConcurrentDB is %T, want *dbx.DB", app.ConcurrentDB())
+	}
+	nonconcurrent, _ := app.NonconcurrentDB().(*dbx.DB)
+
+	var count int64
+	queryLog := func(_ context.Context, _ time.Duration, query string, _ *sql.Rows, _ error) {
+		if strings.Contains(query, "COUNT(DISTINCT artworks.id) AS holding_count") {
+			atomic.AddInt64(&count, 1)
+		}
+	}
+	concurrent.QueryLogFunc = queryLog
+	if nonconcurrent != nil {
+		nonconcurrent.QueryLogFunc = queryLog
+	}
+	defer func() {
+		concurrent.QueryLogFunc = nil
+		if nonconcurrent != nil {
+			nonconcurrent.QueryLogFunc = nil
+		}
+	}()
+
+	if err := fn(); err != nil {
+		return 0, err
+	}
+	return int(atomic.LoadInt64(&count)), nil
+}

--- a/internal/handlers/artworks/getters.go
+++ b/internal/handlers/artworks/getters.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blackfyre/wga/internal/assets/templ/dto"
 	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/repositories"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
 	"github.com/pocketbase/pocketbase"
@@ -30,13 +31,12 @@ const artworkVenueOptionsLimit = 40
 const artworkLocationOptionsLimit = artworkVenueOptionsLimit
 
 const (
-	artTypesCacheKey           = "artworks:search:art-types"
-	artFormsCacheKey           = "artworks:search:art-forms"
-	artSchoolsCacheKey         = "artworks:search:art-schools"
-	artistNamesCacheKey        = "artworks:search:artist-names"
-	artPeriodsCacheKey         = "artworks:search:art-periods"
-	locationsCacheKey          = "artworks:search:locations"
-	collectionHoldingsCacheKey = "artworks:search:collection-holdings"
+	artTypesCacheKey    = "artworks:search:art-types"
+	artFormsCacheKey    = "artworks:search:art-forms"
+	artSchoolsCacheKey  = "artworks:search:art-schools"
+	artistNamesCacheKey = "artworks:search:artist-names"
+	artPeriodsCacheKey  = "artworks:search:art-periods"
+	locationsCacheKey   = "artworks:search:locations"
 )
 
 // getArtTypesOptions returns a map of art type slugs and their corresponding names.
@@ -339,70 +339,28 @@ type venueFacetOptions struct {
 	unknownSelected bool
 }
 
-type collectionHoldingRow struct {
-	Value        string `db:"value"`
-	Label        string `db:"label"`
-	HoldingCount int    `db:"holding_count"`
-}
-
-// collectionHoldings loads every location and its eligible published-work
-// count. Zero-count locations remain in the compact projection so an existing
-// selected value can be retained without another query.
-func collectionHoldings(app *pocketbase.PocketBase) ([]venueOption, error) {
-	return utils.GetOrLoadCachedValue(app, collectionHoldingsCacheKey, 0, func() ([]venueOption, error) {
-		rows := []collectionHoldingRow{}
-		err := app.DB().NewQuery(`
-			SELECT
-				locations.id AS value,
-				locations.name AS label,
-				COUNT(DISTINCT artworks.id) AS holding_count
-			FROM locations
-			LEFT JOIN artworks
-				ON artworks.current_location_id = locations.id
-				AND artworks.published = TRUE
-				AND json_array_length(artworks.author) > 0
-				AND EXISTS (
-					SELECT 1 FROM artists
-					WHERE artists.id = json_extract(artworks.author, '$[0]')
-				)
-			GROUP BY locations.id, locations.name`).All(&rows)
-		if err != nil {
-			return nil, err
-		}
-
-		holdings := make([]venueOption, 0, len(rows))
-		for _, row := range rows {
-			holdings = append(holdings, venueOption{
-				value: row.Value,
-				label: row.Label,
-				count: row.HoldingCount,
-			})
-		}
-		return holdings, nil
-	})
-}
-
 // getVenueOptions filters, orders, and bounds the complete counted holdings
 // projection in memory. VenueQuery changes only the collection choices; it never
 // enters the artwork result predicate or a holding's own count.
 func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenue string) (venueFacetOptions, error) {
-	holdings, err := collectionHoldings(app)
+	holdings, err := repositories.LoadCollectionHoldings(app)
 	if err != nil {
 		return venueFacetOptions{}, err
 	}
 
 	options := venueFacetOptions{entries: make([]venueOption, 0, min(len(holdings), artworkVenueOptionsLimit))}
 	for _, holding := range holdings {
-		if selectedVenue != "" && holding.value == selectedVenue {
-			options.retained = holding
+		option := venueOption{value: holding.Value, label: holding.Label, count: holding.Count}
+		if selectedVenue != "" && option.value == selectedVenue {
+			options.retained = option
 			options.retainedSet = true
 		}
-		if holding.count <= 0 || !venueNameMatchesQuery(holding.label, venueQuery) {
+		if option.count <= 0 || !venueNameMatchesQuery(option.label, venueQuery) {
 			continue
 		}
-		options.entries = append(options.entries, holding)
+		options.entries = append(options.entries, option)
 		options.totalOptions++
-		options.totalHoldings += holding.count
+		options.totalHoldings += option.count
 	}
 
 	sort.Slice(options.entries, func(i, j int) bool {

--- a/internal/handlers/artworks/getters.go
+++ b/internal/handlers/artworks/getters.go
@@ -10,7 +10,6 @@ import (
 	"github.com/blackfyre/wga/internal/constants"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
-	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
 )
 
@@ -31,12 +30,13 @@ const artworkVenueOptionsLimit = 40
 const artworkLocationOptionsLimit = artworkVenueOptionsLimit
 
 const (
-	artTypesCacheKey    = "artworks:search:art-types"
-	artFormsCacheKey    = "artworks:search:art-forms"
-	artSchoolsCacheKey  = "artworks:search:art-schools"
-	artistNamesCacheKey = "artworks:search:artist-names"
-	artPeriodsCacheKey  = "artworks:search:art-periods"
-	locationsCacheKey   = "artworks:search:locations"
+	artTypesCacheKey           = "artworks:search:art-types"
+	artFormsCacheKey           = "artworks:search:art-forms"
+	artSchoolsCacheKey         = "artworks:search:art-schools"
+	artistNamesCacheKey        = "artworks:search:artist-names"
+	artPeriodsCacheKey         = "artworks:search:art-periods"
+	locationsCacheKey          = "artworks:search:locations"
+	collectionHoldingsCacheKey = "artworks:search:collection-holdings"
 )
 
 // getArtTypesOptions returns a map of art type slugs and their corresponding names.
@@ -324,10 +324,10 @@ type venueOption struct {
 	count int
 }
 
-// venueFacetOptions is the bounded result of the single collection aggregate.
-// retained carries the selected venue when it is a real holding that fell
-// outside the forty-option cap or was excluded by venue_q; unknownSelected is
-// set when the selected venue has no matching location record at all.
+// venueFacetOptions is the bounded result derived from the complete collection
+// projection. retained carries an existing selected location that fell outside
+// the forty-option cap or was excluded by venue_q; unknownSelected is set when
+// the selected venue has no matching location record at all.
 type venueFacetOptions struct {
 	entries         []venueOption
 	totalOptions    int
@@ -339,126 +339,115 @@ type venueFacetOptions struct {
 	unknownSelected bool
 }
 
-type venueOptionRow struct {
-	Value         string `db:"value"`
-	Label         string `db:"label"`
-	HoldingCount  int    `db:"holding_count"`
-	TotalOptions  int    `db:"total_options"`
-	TotalHoldings int    `db:"total_holdings"`
+type collectionHoldingRow struct {
+	Value        string `db:"value"`
+	Label        string `db:"label"`
+	HoldingCount int    `db:"holding_count"`
 }
 
-// getVenueOptions returns at most forty collection options from one aggregate
-// query. Counts include only published works whose first author exists, matching
-// the artwork-search result predicate without a stricter artist-published rule.
-// VenueQuery is applied only to collection names; it never enters the artwork
-// result predicate or a holding's own count.
-func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenue string) (venueFacetOptions, error) {
-	query := `
-		WITH eligible_holdings AS (
+// collectionHoldings loads every location and its eligible published-work
+// count. Zero-count locations remain in the compact projection so an existing
+// selected value can be retained without another query.
+func collectionHoldings(app *pocketbase.PocketBase) ([]venueOption, error) {
+	return utils.GetOrLoadCachedValue(app, collectionHoldingsCacheKey, 0, func() ([]venueOption, error) {
+		rows := []collectionHoldingRow{}
+		err := app.DB().NewQuery(`
 			SELECT
 				locations.id AS value,
 				locations.name AS label,
 				COUNT(DISTINCT artworks.id) AS holding_count
 			FROM locations
-			INNER JOIN artworks ON artworks.current_location_id = locations.id
-			INNER JOIN artists ON artists.id = json_extract(artworks.author, '$[0]')
-			WHERE artworks.published = TRUE
+			LEFT JOIN artworks
+				ON artworks.current_location_id = locations.id
+				AND artworks.published = TRUE
 				AND json_array_length(artworks.author) > 0
-				AND ({:venue_query} = '' OR instr(lower(locations.name), lower({:venue_query})) > 0)
-			GROUP BY locations.id, locations.name
-		), counted_holdings AS (
-			SELECT
-				value,
-				label,
-				holding_count,
-				COUNT(*) OVER () AS total_options,
-				SUM(holding_count) OVER () AS total_holdings
-			FROM eligible_holdings
-		)
-		SELECT value, label, holding_count, total_options, total_holdings
-		FROM counted_holdings
-		ORDER BY holding_count DESC, label COLLATE NOCASE ASC, label ASC, value ASC
-		LIMIT {:limit}`
+				AND EXISTS (
+					SELECT 1 FROM artists
+					WHERE artists.id = json_extract(artworks.author, '$[0]')
+				)
+			GROUP BY locations.id, locations.name`).All(&rows)
+		if err != nil {
+			return nil, err
+		}
 
-	rows := []venueOptionRow{}
-	err := app.DB().NewQuery(query).Bind(dbx.Params{
-		"venue_query": venueQuery,
-		"limit":       artworkVenueOptionsLimit,
-	}).All(&rows)
+		holdings := make([]venueOption, 0, len(rows))
+		for _, row := range rows {
+			holdings = append(holdings, venueOption{
+				value: row.Value,
+				label: row.Label,
+				count: row.HoldingCount,
+			})
+		}
+		return holdings, nil
+	})
+}
+
+// getVenueOptions filters, orders, and bounds the complete counted holdings
+// projection in memory. VenueQuery changes only the collection choices; it never
+// enters the artwork result predicate or a holding's own count.
+func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenue string) (venueFacetOptions, error) {
+	holdings, err := collectionHoldings(app)
 	if err != nil {
 		return venueFacetOptions{}, err
 	}
 
-	options := venueFacetOptions{
-		entries: make([]venueOption, 0, len(rows)),
-	}
-	seenSelected := false
-	for _, row := range rows {
-		options.entries = append(options.entries, venueOption{
-			value: row.Value,
-			label: row.Label,
-			count: row.HoldingCount,
-		})
-		options.totalOptions = row.TotalOptions
-		options.totalHoldings = row.TotalHoldings
-		if selectedVenue != "" && row.Value == selectedVenue {
-			seenSelected = true
+	options := venueFacetOptions{entries: make([]venueOption, 0, min(len(holdings), artworkVenueOptionsLimit))}
+	for _, holding := range holdings {
+		if selectedVenue != "" && holding.value == selectedVenue {
+			options.retained = holding
+			options.retainedSet = true
 		}
+		if holding.count <= 0 || !venueNameMatchesQuery(holding.label, venueQuery) {
+			continue
+		}
+		options.entries = append(options.entries, holding)
+		options.totalOptions++
+		options.totalHoldings += holding.count
 	}
 
-	if selectedVenue != "" && !seenSelected {
-		if err := retainSelectedVenue(app, selectedVenue, &options); err != nil {
-			return venueFacetOptions{}, err
+	sort.Slice(options.entries, func(i, j int) bool {
+		left, right := options.entries[i], options.entries[j]
+		if left.count != right.count {
+			return left.count > right.count
 		}
+		leftFolded, rightFolded := sqliteNoCaseKey(left.label), sqliteNoCaseKey(right.label)
+		if leftFolded != rightFolded {
+			return leftFolded < rightFolded
+		}
+		if left.label != right.label {
+			return left.label < right.label
+		}
+		return left.value < right.value
+	})
+	if len(options.entries) > artworkVenueOptionsLimit {
+		options.entries = options.entries[:artworkVenueOptionsLimit]
+	}
+
+	selectedShown := false
+	for _, entry := range options.entries {
+		if entry.value == selectedVenue {
+			selectedShown = true
+			break
+		}
+	}
+	if selectedVenue != "" && selectedShown {
+		options.retainedSet = false
+	} else if selectedVenue != "" && !options.retainedSet {
+		options.unknownSelected = true
 	}
 
 	finalizeVenueOptions(venueQuery, selectedVenue, &options)
-
 	return options, nil
 }
 
-// retainSelectedVenue resolves the selected venue when it fell outside the
-// capped list or the name query. A real holding is retained with its name and
-// full eligible count; a value with no location record is marked unknown so the
-// facet can render an honest zero/unavailable choice rather than dropping the
-// selection.
-func retainSelectedVenue(app *pocketbase.PocketBase, selectedVenue string, options *venueFacetOptions) error {
-	rows := []venueOptionRow{}
-	err := app.DB().NewQuery(`
-		SELECT
-			locations.id AS value,
-			locations.name AS label,
-			COUNT(artworks.id) AS holding_count
-		FROM locations
-		LEFT JOIN artworks
-			ON artworks.current_location_id = locations.id
-			AND artworks.published = TRUE
-			AND json_array_length(artworks.author) > 0
-			AND EXISTS (
-				SELECT 1 FROM artists
-				WHERE artists.id = json_extract(artworks.author, '$[0]')
-			)
-		WHERE locations.id = {:venue_id}
-		GROUP BY locations.id, locations.name`).Bind(dbx.Params{
-		"venue_id": selectedVenue,
-	}).All(&rows)
-	if err != nil {
-		return err
+func sqliteNoCaseKey(value string) string {
+	folded := []byte(value)
+	for i, char := range folded {
+		if char >= 'A' && char <= 'Z' {
+			folded[i] = char + ('a' - 'A')
+		}
 	}
-
-	if len(rows) == 0 {
-		options.unknownSelected = true
-		return nil
-	}
-
-	options.retained = venueOption{
-		value: rows[0].Value,
-		label: rows[0].Label,
-		count: rows[0].HoldingCount,
-	}
-	options.retainedSet = true
-
-	return nil
+	return string(folded)
 }
 
 // unknownVenueLabel is the honest display label for a selected venue value that
@@ -524,7 +513,7 @@ func venueNameMatchesQuery(label string, query string) bool {
 		return true
 	}
 
-	return strings.Contains(strings.ToLower(label), strings.ToLower(query))
+	return strings.Contains(sqliteNoCaseKey(label), sqliteNoCaseKey(query))
 }
 
 func venueFacetNote(options venueFacetOptions) string {

--- a/internal/handlers/artworks/getters.go
+++ b/internal/handlers/artworks/getters.go
@@ -348,7 +348,7 @@ func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenu
 		return venueFacetOptions{}, err
 	}
 
-	options := venueFacetOptions{entries: make([]venueOption, 0, min(len(holdings), artworkVenueOptionsLimit))}
+	options := venueFacetOptions{entries: make([]venueOption, 0, len(holdings))}
 	for _, holding := range holdings {
 		option := venueOption{value: holding.Value, label: holding.Label, count: holding.Count}
 		if selectedVenue != "" && option.value == selectedVenue {
@@ -368,9 +368,8 @@ func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenu
 		if left.count != right.count {
 			return left.count > right.count
 		}
-		leftFolded, rightFolded := sqliteNoCaseKey(left.label), sqliteNoCaseKey(right.label)
-		if leftFolded != rightFolded {
-			return leftFolded < rightFolded
+		if foldedOrder := sqliteNoCaseCompare(left.label, right.label); foldedOrder != 0 {
+			return foldedOrder < 0
 		}
 		if left.label != right.label {
 			return left.label < right.label
@@ -396,6 +395,33 @@ func getVenueOptions(app *pocketbase.PocketBase, venueQuery string, selectedVenu
 
 	finalizeVenueOptions(venueQuery, selectedVenue, &options)
 	return options, nil
+}
+
+// sqliteNoCaseCompare mirrors SQLite's ASCII-only NOCASE byte ordering without
+// allocating folded strings for each sort comparison.
+func sqliteNoCaseCompare(left string, right string) int {
+	for i := 0; i < min(len(left), len(right)); i++ {
+		leftByte, rightByte := left[i], right[i]
+		if leftByte >= 'A' && leftByte <= 'Z' {
+			leftByte += 'a' - 'A'
+		}
+		if rightByte >= 'A' && rightByte <= 'Z' {
+			rightByte += 'a' - 'A'
+		}
+		if leftByte < rightByte {
+			return -1
+		}
+		if leftByte > rightByte {
+			return 1
+		}
+	}
+	if len(left) < len(right) {
+		return -1
+	}
+	if len(left) > len(right) {
+		return 1
+	}
+	return 0
 }
 
 func sqliteNoCaseKey(value string) string {

--- a/internal/handlers/artworks/getters.go
+++ b/internal/handlers/artworks/getters.go
@@ -497,7 +497,7 @@ func venueNameMatchesQuery(label string, query string) bool {
 		return true
 	}
 
-	return strings.Contains(sqliteNoCaseKey(label), sqliteNoCaseKey(query))
+	return strings.Contains(strings.ToLower(label), strings.ToLower(query))
 }
 
 func venueFacetNote(options venueFacetOptions) string {

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -103,20 +103,27 @@ func buildArtworkSearchView(app *pocketbase.PocketBase, values neturl.Values, pa
 
 type artworkSearchCheckpoint func(context.Context, string) error
 
-func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBase, values neturl.Values, page int, limit int, checkpoint artworkSearchCheckpoint) (pages.ArtworkSearchView, string, error) {
+type artworkSearchResultsContext struct {
+	filters         *filters
+	dualModeContext *pages.ArtworkSearchDualMode
+	view            pages.ArtworkSearchResultsView
+	canonical       string
+}
+
+func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.PocketBase, values neturl.Values, page int, limit int, checkpoint artworkSearchCheckpoint) (artworkSearchResultsContext, error) {
 	filters := buildFilters(values)
 	dualModeContext := getDualModeSearchContext(values)
 
 	if filters.VenueConflict {
-		return pages.ArtworkSearchView{}, "", errConflictingVenueFilters
+		return artworkSearchResultsContext{}, errConflictingVenueFilters
 	}
 
 	if err := checkpoint(ctx, "artworks.search.count"); err != nil {
-		return pages.ArtworkSearchView{}, "", err
+		return artworkSearchResultsContext{}, err
 	}
 	recordsCount, err := countArtworkRecords(app, filters)
 	if err != nil {
-		return pages.ArtworkSearchView{}, "", err
+		return artworkSearchResultsContext{}, err
 	}
 
 	pageCount := (recordsCount + limit - 1) / limit
@@ -129,12 +136,36 @@ func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBa
 	offset := (page - 1) * limit
 
 	if err := checkpoint(ctx, "artworks.search.records"); err != nil {
-		return pages.ArtworkSearchView{}, "", err
+		return artworkSearchResultsContext{}, err
 	}
 	records, err := listArtworkRecords(app, filters, limit, offset)
 	if err != nil {
+		return artworkSearchResultsContext{}, err
+	}
+
+	if err := checkpoint(ctx, "artworks.search.projection"); err != nil {
+		return artworkSearchResultsContext{}, err
+	}
+	view, err := buildArtworkSearchResults(app, filters, dualModeContext, records, recordsCount, page, limit)
+	if err != nil {
+		return artworkSearchResultsContext{}, err
+	}
+
+	return artworkSearchResultsContext{
+		filters:         filters,
+		dualModeContext: dualModeContext,
+		view:            view,
+		canonical:       buildArtworkSearchPath("/artworks", filters, dualModeContext),
+	}, nil
+}
+
+func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBase, values neturl.Values, page int, limit int, checkpoint artworkSearchCheckpoint) (pages.ArtworkSearchView, string, error) {
+	resultsContext, err := buildArtworkSearchResultsViewContext(ctx, app, values, page, limit, checkpoint)
+	if err != nil {
 		return pages.ArtworkSearchView{}, "", err
 	}
+	filters := resultsContext.filters
+	dualModeContext := resultsContext.dualModeContext
 
 	if err := checkpoint(ctx, "artworks.search.forms"); err != nil {
 		return pages.ArtworkSearchView{}, "", err
@@ -171,14 +202,6 @@ func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBa
 	if err != nil {
 		return pages.ArtworkSearchView{}, "", err
 	}
-	if err := checkpoint(ctx, "artworks.search.projection"); err != nil {
-		return pages.ArtworkSearchView{}, "", err
-	}
-	results, err := buildArtworkSearchResults(app, filters, dualModeContext, records, recordsCount, page, limit)
-	if err != nil {
-		return pages.ArtworkSearchView{}, "", err
-	}
-
 	schoolGroup := buildChipGroup("SCHOOL", "art_school", artSchoolOptions, filters.SchoolString)
 	formGroup := buildChipGroup("FORM", "art_form", artFormOptions, filters.ArtFormString)
 	typeGroup := buildChipGroup("TYPE", "art_type", artTypeOptions, filters.ArtTypeString)
@@ -214,12 +237,10 @@ func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBa
 		ClearUrl:        buildArtworkSearchClearPath(dualModeContext),
 		DualModeContext: dualModeContext,
 		HxTarget:        "#artwork-search",
-		Results:         results,
+		Results:         resultsContext.view,
 	}
 
-	canonical := buildArtworkSearchPath("/artworks", filters, dualModeContext)
-
-	return view, canonical, nil
+	return view, resultsContext.canonical, nil
 }
 
 func buildArtworkSearchResults(app *pocketbase.PocketBase, filters *filters, dualModeContext *pages.ArtworkSearchDualMode, records []*core.Record, recordsCount int, page int, limit int) (pages.ArtworkSearchResultsView, error) {

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -163,9 +163,28 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 	if err := checkpoint(ctx, "artworks.search.count"); err != nil {
 		return artworkSearchResultsContext{}, err
 	}
-	recordsCount, err := countArtworkRecords(app, filters)
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
 	if err != nil {
 		return artworkSearchResultsContext{}, err
+	}
+	offset := (page - 1) * limit
+	pageRows, err := listArtworkPageRowsForCollection(app, collection, filters, limit, offset)
+	if err != nil {
+		return artworkSearchResultsContext{}, err
+	}
+	recordsCount := 0
+	if len(pageRows) > 0 {
+		recordsCount = pageRows[0].Total
+	} else if page > 1 {
+		// A window query returns no total when OFFSET is beyond the last row. Load
+		// the first page to recover the total, then select the canonical last page.
+		pageRows, err = listArtworkPageRowsForCollection(app, collection, filters, limit, 0)
+		if err != nil {
+			return artworkSearchResultsContext{}, err
+		}
+		if len(pageRows) > 0 {
+			recordsCount = pageRows[0].Total
+		}
 	}
 
 	pageCount := (recordsCount + limit - 1) / limit
@@ -173,14 +192,19 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 		page = 1
 	} else if page > pageCount {
 		page = pageCount
+		if page > 1 {
+			pageRows, err = listArtworkPageRowsForCollection(app, collection, filters, limit, (page-1)*limit)
+			if err != nil {
+				return artworkSearchResultsContext{}, err
+			}
+		}
 	}
 	filters.Page = strconv.Itoa(page)
-	offset := (page - 1) * limit
 
 	if err := checkpoint(ctx, "artworks.search.records"); err != nil {
 		return artworkSearchResultsContext{}, err
 	}
-	records, err := listArtworkRecords(app, filters, limit, offset)
+	records, err := listArtworkRecordsByPageRowsForCollection(app, collection, pageRows)
 	if err != nil {
 		return artworkSearchResultsContext{}, err
 	}

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	neturl "net/url"
 	"strconv"
@@ -15,6 +16,7 @@ import (
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
 	tmplUtils "github.com/blackfyre/wga/internal/assets/templ/utils"
 	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/repositories"
 	"github.com/blackfyre/wga/internal/requestprotection"
 	"github.com/blackfyre/wga/internal/utils"
 	"github.com/blackfyre/wga/internal/utils/url"
@@ -171,7 +173,8 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 	var records []*core.Record
 	var recordsCount int
 	for attempt := 0; attempt < 2; attempt++ {
-		offset := (requestedPage - 1) * limit
+		revision := repositories.ArtworkCatalogueRevision(app)
+		offset := artworkSearchPageOffset(requestedPage, limit)
 		pageRows, rowsErr := listArtworkPageRowsForCollection(app, collection, filters, limit, offset)
 		if rowsErr != nil {
 			return artworkSearchResultsContext{}, rowsErr
@@ -200,6 +203,9 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 			return artworkSearchResultsContext{}, err
 		}
 		records, rowsErr = listArtworkRecordsByPageRowsForCollection(app, collection, filters, pageRows)
+		if rowsErr == nil && revision != repositories.ArtworkCatalogueRevision(app) {
+			rowsErr = errArtworkPageChanged
+		}
 		if !errors.Is(rowsErr, errArtworkPageChanged) {
 			if rowsErr != nil {
 				return artworkSearchResultsContext{}, rowsErr
@@ -225,6 +231,16 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 		view:            view,
 		canonical:       buildArtworkSearchPath("/artworks", filters, dualModeContext),
 	}, nil
+}
+
+func artworkSearchPageOffset(page int, limit int) int {
+	if page <= 1 || limit <= 0 {
+		return 0
+	}
+	if page-1 > math.MaxInt/limit {
+		return math.MaxInt
+	}
+	return (page - 1) * limit
 }
 
 func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBase, values neturl.Values, page int, limit int, checkpoint artworkSearchCheckpoint) (pages.ArtworkSearchView, string, error) {

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -167,46 +167,48 @@ func buildArtworkSearchResultsViewContext(ctx context.Context, app *pocketbase.P
 	if err != nil {
 		return artworkSearchResultsContext{}, err
 	}
-	offset := (page - 1) * limit
-	pageRows, err := listArtworkPageRowsForCollection(app, collection, filters, limit, offset)
-	if err != nil {
-		return artworkSearchResultsContext{}, err
-	}
-	recordsCount := 0
-	if len(pageRows) > 0 {
-		recordsCount = pageRows[0].Total
-	} else if page > 1 {
-		// A window query returns no total when OFFSET is beyond the last row. Load
-		// the first page to recover the total, then select the canonical last page.
-		pageRows, err = listArtworkPageRowsForCollection(app, collection, filters, limit, 0)
-		if err != nil {
-			return artworkSearchResultsContext{}, err
+	requestedPage := page
+	var records []*core.Record
+	var recordsCount int
+	for attempt := 0; attempt < 2; attempt++ {
+		offset := (requestedPage - 1) * limit
+		pageRows, rowsErr := listArtworkPageRowsForCollection(app, collection, filters, limit, offset)
+		if rowsErr != nil {
+			return artworkSearchResultsContext{}, rowsErr
 		}
+		if len(pageRows) == 0 && requestedPage > 1 {
+			pageRows, rowsErr = listCanonicalArtworkPageRows(app, collection, filters, limit)
+			if rowsErr != nil {
+				return artworkSearchResultsContext{}, rowsErr
+			}
+		}
+
+		recordsCount = 0
 		if len(pageRows) > 0 {
 			recordsCount = pageRows[0].Total
 		}
-	}
-
-	pageCount := (recordsCount + limit - 1) / limit
-	if pageCount == 0 {
-		page = 1
-	} else if page > pageCount {
-		page = pageCount
-		if page > 1 {
-			pageRows, err = listArtworkPageRowsForCollection(app, collection, filters, limit, (page-1)*limit)
-			if err != nil {
-				return artworkSearchResultsContext{}, err
-			}
+		pageCount := (recordsCount + limit - 1) / limit
+		page = requestedPage
+		if pageCount == 0 {
+			page = 1
+		} else if page > pageCount {
+			page = pageCount
 		}
-	}
-	filters.Page = strconv.Itoa(page)
+		filters.Page = strconv.Itoa(page)
 
-	if err := checkpoint(ctx, "artworks.search.records"); err != nil {
-		return artworkSearchResultsContext{}, err
-	}
-	records, err := listArtworkRecordsByPageRowsForCollection(app, collection, pageRows)
-	if err != nil {
-		return artworkSearchResultsContext{}, err
+		if err := checkpoint(ctx, "artworks.search.records"); err != nil {
+			return artworkSearchResultsContext{}, err
+		}
+		records, rowsErr = listArtworkRecordsByPageRowsForCollection(app, collection, filters, pageRows)
+		if !errors.Is(rowsErr, errArtworkPageChanged) {
+			if rowsErr != nil {
+				return artworkSearchResultsContext{}, rowsErr
+			}
+			break
+		}
+		if attempt == 1 {
+			return artworkSearchResultsContext{}, rowsErr
+		}
 	}
 
 	if err := checkpoint(ctx, "artworks.search.projection"); err != nil {

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -32,6 +32,34 @@ func searchPage(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 }
 
 func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
+	return searchWithCheckpoint(app, c, requestprotection.Checkpoint)
+}
+
+type artworkSearchResponseKind uint8
+
+const (
+	artworkSearchFullPage artworkSearchResponseKind = iota
+	artworkSearchBlock
+	artworkSearchResultsFragment
+)
+
+func artworkSearchResponseFor(c *core.RequestEvent) artworkSearchResponseKind {
+	if !utils.IsHtmxRequest(c) {
+		return artworkSearchFullPage
+	}
+
+	htmxTarget := strings.TrimPrefix(strings.TrimSpace(c.Request.Header.Get("HX-Target")), "#")
+	if htmxTarget == "artwork-search" {
+		return artworkSearchBlock
+	}
+	if c.Request.URL.Path == "/artworks/results" {
+		return artworkSearchResultsFragment
+	}
+
+	return artworkSearchFullPage
+}
+
+func searchWithCheckpoint(app *pocketbase.PocketBase, c *core.RequestEvent, checkpoint artworkSearchCheckpoint) error {
 	page := 1
 
 	queryParams := c.Request.URL.Query()
@@ -44,7 +72,22 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 		page = parsed
 	}
 
-	view, canonical, err := buildArtworkSearchViewContext(c.Request.Context(), app, queryParams, page, artworkSearchPageSize, requestprotection.Checkpoint)
+	responseKind := artworkSearchResponseFor(c)
+	var view pages.ArtworkSearchView
+	var results pages.ArtworkSearchResultsView
+	var canonical string
+	var err error
+	if responseKind == artworkSearchResultsFragment {
+		resultsContext, resultsErr := buildArtworkSearchResultsViewContext(c.Request.Context(), app, queryParams, page, artworkSearchPageSize, checkpoint)
+		if resultsErr == nil {
+			results = resultsContext.view
+			canonical = resultsContext.canonical
+		}
+		err = resultsErr
+	} else {
+		view, canonical, err = buildArtworkSearchViewContext(c.Request.Context(), app, queryParams, page, artworkSearchPageSize, checkpoint)
+		results = view.Results
+	}
 	if err != nil {
 		if requestprotection.IsCancellation(err) {
 			return err
@@ -66,12 +109,11 @@ func search(app *pocketbase.PocketBase, c *core.RequestEvent) error {
 	var buff bytes.Buffer
 
 	err = renderArtworkSearch(c.Request.Context(), func() error {
-		htmxTarget := strings.TrimPrefix(strings.TrimSpace(c.Request.Header.Get("HX-Target")), "#")
-		switch {
-		case utils.IsHtmxRequest(c) && htmxTarget == "artwork-search":
+		switch responseKind {
+		case artworkSearchBlock:
 			return pages.ArtworkSearchBlock(view).Render(ctx, &buff)
-		case utils.IsHtmxRequest(c) && c.Request.URL.Path == "/artworks/results":
-			return pages.ArtworkSearchResults(view.Results).Render(ctx, &buff)
+		case artworkSearchResultsFragment:
+			return pages.ArtworkSearchResults(results).Render(ctx, &buff)
 		default:
 			return pages.ArtworkSearchPage(view).Render(ctx, &buff)
 		}

--- a/internal/handlers/artworks/query.go
+++ b/internal/handlers/artworks/query.go
@@ -1,12 +1,18 @@
 package artworks
 
 import (
-	"github.com/blackfyre/wga/internal/constants"
+	"fmt"
+
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 	pbsearch "github.com/pocketbase/pocketbase/tools/search"
 )
+
+type artworkPageRow struct {
+	ID    string `db:"id"`
+	Total int    `db:"total"`
+}
 
 // attachArtworkConditions attaches the catalogue filter conditions to the query.
 func attachArtworkConditions(query *dbx.SelectQuery, resolver *core.RecordFieldResolver, f *filters) error {
@@ -44,17 +50,13 @@ func attachArtworkSort(query *dbx.SelectQuery, resolver *core.RecordFieldResolve
 	return nil
 }
 
-// listArtworkRecords returns the bounded page of artwork records matching the
-// filters, in deterministic sort order.
-func listArtworkRecords(app *pocketbase.PocketBase, f *filters, limit int, offset int) ([]*core.Record, error) {
-	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
-	if err != nil {
-		return nil, err
-	}
-
-	query := app.RecordQuery(collection)
+// listArtworkPageRows evaluates the filtered, ordered page and its complete
+// result count in one pass. Record hydration is deliberately separate and
+// bounded to these IDs so the expensive filter predicates are not repeated.
+func listArtworkPageRowsForCollection(app *pocketbase.PocketBase, collection *core.Collection, f *filters, limit int, offset int) ([]artworkPageRow, error) {
+	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
+	query := app.RecordQuery(collection).Select(baseID+" AS id", "COUNT(*) OVER() AS total")
 	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
-
 	if err := attachArtworkConditions(query, resolver, f); err != nil {
 		return nil, err
 	}
@@ -64,7 +66,6 @@ func listArtworkRecords(app *pocketbase.PocketBase, f *filters, limit int, offse
 	if err := resolver.UpdateQuery(query); err != nil {
 		return nil, err
 	}
-
 	if offset > 0 {
 		query.Offset(int64(offset))
 	}
@@ -72,39 +73,41 @@ func listArtworkRecords(app *pocketbase.PocketBase, f *filters, limit int, offse
 		query.Limit(int64(limit))
 	}
 
-	records := []*core.Record{}
-	if err := query.All(&records); err != nil {
+	rows := []artworkPageRow{}
+	if err := query.All(&rows); err != nil {
 		return nil, err
 	}
-
-	return records, nil
+	return rows, nil
 }
 
-// countArtworkRecords returns the number of artwork records matching the
-// filters. The count ignores sorting and reuses the same condition set so the
-// page total always matches the list query.
-func countArtworkRecords(app *pocketbase.PocketBase, f *filters) (int, error) {
-	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
-	if err != nil {
-		return 0, err
+// listArtworkRecordsByPageRowsForCollection hydrates the bounded page and
+// restores the exact order selected by listArtworkPageRowsForCollection.
+func listArtworkRecordsByPageRowsForCollection(app *pocketbase.PocketBase, collection *core.Collection, rows []artworkPageRow) ([]*core.Record, error) {
+	if len(rows) == 0 {
+		return nil, nil
 	}
-
 	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
-
-	query := app.RecordQuery(collection).Select("COUNT(DISTINCT " + baseID + ")")
-	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
-
-	if err := attachArtworkConditions(query, resolver, f); err != nil {
-		return 0, err
-	}
-	if err := resolver.UpdateQuery(query); err != nil {
-		return 0, err
+	ids := make([]any, len(rows))
+	for i, row := range rows {
+		ids[i] = row.ID
 	}
 
-	var count int
-	if err := query.Row(&count); err != nil {
-		return 0, err
+	records := []*core.Record{}
+	if err := app.RecordQuery(collection).AndWhere(dbx.In(baseID, ids...)).All(&records); err != nil {
+		return nil, err
 	}
-
-	return count, nil
+	byID := make(map[string]*core.Record, len(records))
+	for _, record := range records {
+		byID[record.Id] = record
+	}
+	ordered := make([]*core.Record, 0, len(rows))
+	for _, row := range rows {
+		if record := byID[row.ID]; record != nil {
+			ordered = append(ordered, record)
+		}
+	}
+	if len(ordered) != len(rows) {
+		return nil, fmt.Errorf("hydrate artwork page: found %d of %d selected records", len(ordered), len(rows))
+	}
+	return ordered, nil
 }

--- a/internal/handlers/artworks/query.go
+++ b/internal/handlers/artworks/query.go
@@ -1,10 +1,11 @@
 package artworks
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/pocketbase/dbx"
-	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"
 	pbsearch "github.com/pocketbase/pocketbase/tools/search"
 )
@@ -13,6 +14,8 @@ type artworkPageRow struct {
 	ID    string `db:"id"`
 	Total int    `db:"total"`
 }
+
+var errArtworkPageChanged = errors.New("artwork page changed during hydration")
 
 // attachArtworkConditions attaches the catalogue filter conditions to the query.
 func attachArtworkConditions(query *dbx.SelectQuery, resolver *core.RecordFieldResolver, f *filters) error {
@@ -51,9 +54,15 @@ func attachArtworkSort(query *dbx.SelectQuery, resolver *core.RecordFieldResolve
 }
 
 // listArtworkPageRows evaluates the filtered, ordered page and its complete
-// result count in one pass. Record hydration is deliberately separate and
-// bounded to these IDs so the expensive filter predicates are not repeated.
-func listArtworkPageRowsForCollection(app *pocketbase.PocketBase, collection *core.Collection, f *filters, limit int, offset int) ([]artworkPageRow, error) {
+// distinct-artwork count in one pass.
+func listArtworkPageRowsForCollection(app core.App, collection *core.Collection, f *filters, limit int, offset int) ([]artworkPageRow, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("list artwork page rows: limit must be positive")
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
 	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
 	query := app.RecordQuery(collection).Select(baseID+" AS id", "COUNT(*) OVER() AS total")
 	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
@@ -66,12 +75,9 @@ func listArtworkPageRowsForCollection(app *pocketbase.PocketBase, collection *co
 	if err := resolver.UpdateQuery(query); err != nil {
 		return nil, err
 	}
-	if offset > 0 {
-		query.Offset(int64(offset))
-	}
-	if limit > 0 {
-		query.Limit(int64(limit))
-	}
+	query.AndGroupBy(baseID)
+	query.Offset(int64(offset))
+	query.Limit(int64(limit))
 
 	rows := []artworkPageRow{}
 	if err := query.All(&rows); err != nil {
@@ -80,21 +86,85 @@ func listArtworkPageRowsForCollection(app *pocketbase.PocketBase, collection *co
 	return rows, nil
 }
 
-// listArtworkRecordsByPageRowsForCollection hydrates the bounded page and
-// restores the exact order selected by listArtworkPageRowsForCollection.
-func listArtworkRecordsByPageRowsForCollection(app *pocketbase.PocketBase, collection *core.Collection, rows []artworkPageRow) ([]*core.Record, error) {
+// listCanonicalArtworkPageRows recovers the total and canonical last page after
+// a requested offset returns no rows. It materialises the filtered IDs once, so
+// recovery does not issue separate first- and last-page window scans.
+func listCanonicalArtworkPageRows(app core.App, collection *core.Collection, f *filters, limit int) ([]artworkPageRow, error) {
+	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
+	query := app.RecordQuery(collection).Select(baseID + " AS id")
+	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
+	if err := attachArtworkConditions(query, resolver, f); err != nil {
+		return nil, err
+	}
+	if err := attachArtworkSort(query, resolver, f); err != nil {
+		return nil, err
+	}
+	if err := resolver.UpdateQuery(query); err != nil {
+		return nil, err
+	}
+	orderBy := strings.Join(query.Info().OrderBy, ", ")
+	if orderBy == "" {
+		return nil, fmt.Errorf("list canonical artwork page rows: missing deterministic order")
+	}
+	query.AndSelect("ROW_NUMBER() OVER (ORDER BY " + orderBy + ") AS position")
+	query.AndGroupBy(baseID)
+
+	built := query.Build()
+	params := built.Params()
+	params["artwork_page_limit"] = limit
+	pageQuery := app.DB().NewQuery(`
+		WITH matches AS MATERIALIZED (` + built.SQL() + `),
+		tally AS (
+			SELECT COUNT(*) AS total
+			FROM matches
+		),
+		bounds AS (
+			SELECT total, ((total - 1) / {:artwork_page_limit}) * {:artwork_page_limit} AS page_offset
+			FROM tally
+		)
+		SELECT matches.id, bounds.total
+		FROM matches
+		CROSS JOIN bounds
+		WHERE matches.position > bounds.page_offset
+			AND matches.position <= bounds.page_offset + {:artwork_page_limit}
+		ORDER BY matches.position
+	`).Bind(params)
+
+	rows := []artworkPageRow{}
+	if err := pageQuery.All(&rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// listArtworkRecordsByPageRowsForCollection revalidates the bounded page
+// against the active filters while hydrating it. A mismatch tells the caller to
+// repeat selection rather than rendering a stale or deleted record.
+func listArtworkRecordsByPageRowsForCollection(app core.App, collection *core.Collection, f *filters, rows []artworkPageRow) ([]*core.Record, error) {
 	if len(rows) == 0 {
 		return nil, nil
 	}
+
 	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
 	ids := make([]any, len(rows))
 	for i, row := range rows {
 		ids[i] = row.ID
 	}
+	query := app.RecordQuery(collection).AndWhere(dbx.In(baseID, ids...))
+	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
+	if err := attachArtworkConditions(query, resolver, f); err != nil {
+		return nil, err
+	}
+	if err := resolver.UpdateQuery(query); err != nil {
+		return nil, err
+	}
 
 	records := []*core.Record{}
-	if err := app.RecordQuery(collection).AndWhere(dbx.In(baseID, ids...)).All(&records); err != nil {
+	if err := query.All(&records); err != nil {
 		return nil, err
+	}
+	if len(records) != len(rows) {
+		return nil, errArtworkPageChanged
 	}
 	byID := make(map[string]*core.Record, len(records))
 	for _, record := range records {
@@ -105,9 +175,6 @@ func listArtworkRecordsByPageRowsForCollection(app *pocketbase.PocketBase, colle
 		if record := byID[row.ID]; record != nil {
 			ordered = append(ordered, record)
 		}
-	}
-	if len(ordered) != len(rows) {
-		return nil, fmt.Errorf("hydrate artwork page: found %d of %d selected records", len(ordered), len(rows))
 	}
 	return ordered, nil
 }

--- a/internal/handlers/artworks/query_experiment_test.go
+++ b/internal/handlers/artworks/query_experiment_test.go
@@ -1,0 +1,247 @@
+package artworks
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/blackfyre/wga/internal/constants"
+	"github.com/pocketbase/pocketbase"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// listArtworkRecords is the pre-task-6.1 baseline retained only for the
+// evidence benchmark and equivalence test.
+func listArtworkRecords(app *pocketbase.PocketBase, f *filters, limit int, offset int) ([]*core.Record, error) {
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
+	if err != nil {
+		return nil, err
+	}
+	query := app.RecordQuery(collection)
+	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
+	if err := attachArtworkConditions(query, resolver, f); err != nil {
+		return nil, err
+	}
+	if err := attachArtworkSort(query, resolver, f); err != nil {
+		return nil, err
+	}
+	if err := resolver.UpdateQuery(query); err != nil {
+		return nil, err
+	}
+	if offset > 0 {
+		query.Offset(int64(offset))
+	}
+	if limit > 0 {
+		query.Limit(int64(limit))
+	}
+	records := []*core.Record{}
+	if err := query.All(&records); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func countArtworkRecords(app *pocketbase.PocketBase, f *filters) (int, error) {
+	collection, err := app.FindCollectionByNameOrId(constants.CollectionArtworks)
+	if err != nil {
+		return 0, err
+	}
+	baseID := app.DB().QuoteSimpleTableName(collection.Name) + "." + app.DB().QuoteSimpleColumnName("id")
+	query := app.RecordQuery(collection).Select("COUNT(DISTINCT " + baseID + ")")
+	resolver := core.NewRecordFieldResolver(app, collection, nil, true)
+	if err := attachArtworkConditions(query, resolver, f); err != nil {
+		return 0, err
+	}
+	if err := resolver.UpdateQuery(query); err != nil {
+		return 0, err
+	}
+	var count int
+	if err := query.Row(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// combinedArtworkPage is the benchmark adapter for the retained task 6.1 path.
+// It evaluates the filtered, ordered page and total in one window query, then
+// hydrates only the bounded result IDs.
+func combinedArtworkPage(app *pocketbase.PocketBase, f *filters, limit int, offset int) ([]*core.Record, int, error) {
+	collection, err := app.FindCollectionByNameOrId("artworks")
+	if err != nil {
+		return nil, 0, err
+	}
+	rows, err := listArtworkPageRowsForCollection(app, collection, f, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(rows) == 0 {
+		return nil, 0, nil
+	}
+	records, err := listArtworkRecordsByPageRowsForCollection(app, collection, rows)
+	return records, rows[0].Total, err
+}
+
+func TestCombinedArtworkPageMatchesSeparateQueries(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "combineartist01", "Alpha Artist")
+	saveSearchArtist(t, app, "combineartist02", "Beta Artist")
+	saveSearchLocation(t, app, "combineloc00001", "Alpha Museum")
+	saveSearchLocation(t, app, "combineloc00002", "Beta Museum")
+
+	seeds := []searchArtworkSeed{
+		{id: "combinework0001", title: "Madonna Alpha", authors: []string{"combineartist01"}, location: "combineloc00001", year: 1500, sourceRow: 1, published: true},
+		{id: "combinework0002", title: "Portrait", authors: []string{"combineartist02", "combineartist01"}, location: "combineloc00002", year: 1550, sourceRow: 2, published: true},
+		{id: "combinework0003", title: "Madonna Beta", authors: []string{"combineartist02"}, location: "combineloc00001", year: 1650, sourceRow: 3, published: true},
+		{id: "combinework0004", title: "Hidden Madonna", authors: []string{"combineartist01"}, location: "combineloc00001", year: 1500, sourceRow: 4, published: false},
+	}
+	for _, seed := range seeds {
+		saveSearchArtwork(t, app, seed)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		filter filters
+	}{
+		{name: "unfiltered"},
+		{name: "text", filter: filters{Query: "Madonna"}},
+		{name: "exact artist including coauthor", filter: filters{ArtistID: "combineartist01"}},
+		{name: "venue", filter: filters{VenueString: "combineloc00001"}},
+		{name: "date range", filter: filters{YearFrom: "1500", YearTo: "1600"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.filter
+			f.Sort = sortCatalogue
+			f.SortDir = sortAsc
+			separateTotal, err := countArtworkRecords(app, &f)
+			if err != nil {
+				t.Fatalf("count separate records: %v", err)
+			}
+			separate, err := listArtworkRecords(app, &f, 2, 0)
+			if err != nil {
+				t.Fatalf("list separate records: %v", err)
+			}
+			combined, combinedTotal, err := combinedArtworkPage(app, &f, 2, 0)
+			if err != nil {
+				t.Fatalf("load combined page: %v", err)
+			}
+			if combinedTotal != separateTotal {
+				t.Fatalf("combined total = %d, want %d", combinedTotal, separateTotal)
+			}
+			if got, want := experimentRecordIDs(combined), experimentRecordIDs(separate); fmt.Sprint(got) != fmt.Sprint(want) {
+				t.Fatalf("combined IDs = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func experimentRecordIDs(records []*core.Record) []string {
+	ids := make([]string, len(records))
+	for i, record := range records {
+		ids[i] = record.Id
+	}
+	return ids
+}
+
+func TestCombinedArtworkPageProductionEquivalence(t *testing.T) {
+	app, ok := newArtworkExperimentApp(t)
+	if !ok {
+		t.Skip("set WGA_PERF_DATA_DIR to run production-shaped equivalence")
+	}
+
+	for _, tc := range artworkExperimentCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.filter
+			f.Sort = sortCatalogue
+			f.SortDir = sortAsc
+			separateTotal, err := countArtworkRecords(app, &f)
+			if err != nil {
+				t.Fatalf("count separate records: %v", err)
+			}
+			separate, err := listArtworkRecords(app, &f, artworkSearchPageSize, 0)
+			if err != nil {
+				t.Fatalf("list separate records: %v", err)
+			}
+			combined, combinedTotal, err := combinedArtworkPage(app, &f, artworkSearchPageSize, 0)
+			if err != nil {
+				t.Fatalf("load combined page: %v", err)
+			}
+			if combinedTotal != separateTotal || fmt.Sprint(experimentRecordIDs(combined)) != fmt.Sprint(experimentRecordIDs(separate)) {
+				t.Fatalf("combined total/IDs = %d/%v, want %d/%v", combinedTotal, experimentRecordIDs(combined), separateTotal, experimentRecordIDs(separate))
+			}
+		})
+	}
+}
+
+var artworkExperimentRecords []*core.Record
+var artworkExperimentTotal int
+
+func BenchmarkArtworkListCountExperiment(b *testing.B) {
+	app, ok := newArtworkExperimentApp(b)
+	if !ok {
+		b.Skip("set WGA_PERF_DATA_DIR to a production-shaped PocketBase data directory")
+	}
+
+	for _, tc := range artworkExperimentCases() {
+		f := tc.filter
+		f.Sort = sortCatalogue
+		f.SortDir = sortAsc
+		b.Run(tc.name+"/separate", func(b *testing.B) {
+			for range b.N {
+				total, err := countArtworkRecords(app, &f)
+				if err != nil {
+					b.Fatal(err)
+				}
+				records, err := listArtworkRecords(app, &f, artworkSearchPageSize, 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				artworkExperimentRecords = records
+				artworkExperimentTotal = total
+			}
+		})
+		b.Run(tc.name+"/combined", func(b *testing.B) {
+			for range b.N {
+				records, total, err := combinedArtworkPage(app, &f, artworkSearchPageSize, 0)
+				if err != nil {
+					b.Fatal(err)
+				}
+				artworkExperimentRecords = records
+				artworkExperimentTotal = total
+			}
+		})
+	}
+}
+
+func newArtworkExperimentApp(tb testing.TB) (*pocketbase.PocketBase, bool) {
+	tb.Helper()
+	dataDir := os.Getenv("WGA_PERF_DATA_DIR")
+	if dataDir == "" {
+		return nil, false
+	}
+	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: dataDir})
+	if err := app.Bootstrap(); err != nil {
+		tb.Fatalf("bootstrap experiment app: %v", err)
+	}
+	tb.Cleanup(func() {
+		if err := app.ResetBootstrapState(); err != nil {
+			tb.Errorf("reset experiment app: %v", err)
+		}
+	})
+	return app, true
+}
+
+func artworkExperimentCases() []struct {
+	name   string
+	filter filters
+} {
+	return []struct {
+		name   string
+		filter filters
+	}{
+		{name: "unfiltered"},
+		{name: "text", filter: filters{Query: "Madonna"}},
+		{name: "exact_artist", filter: filters{ArtistID: "r3de9890382970b"}},
+		{name: "venue", filter: filters{VenueString: "0f7d9a409f32acf"}},
+		{name: "date_range", filter: filters{YearFrom: "1500", YearTo: "1600"}},
+	}
+}

--- a/internal/handlers/artworks/query_experiment_test.go
+++ b/internal/handlers/artworks/query_experiment_test.go
@@ -77,7 +77,7 @@ func combinedArtworkPage(app *pocketbase.PocketBase, f *filters, limit int, offs
 	if len(rows) == 0 {
 		return nil, 0, nil
 	}
-	records, err := listArtworkRecordsByPageRowsForCollection(app, collection, rows)
+	records, err := listArtworkRecordsByPageRowsForCollection(app, collection, f, rows)
 	return records, rows[0].Total, err
 }
 

--- a/internal/handlers/artworks/search_integration_test.go
+++ b/internal/handlers/artworks/search_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	neturl "net/url"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
 	"github.com/blackfyre/wga/internal/config"
+	"github.com/blackfyre/wga/internal/requestprotection"
 	apputils "github.com/blackfyre/wga/internal/utils"
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase"
@@ -150,6 +152,52 @@ type searchArtworkSeed struct {
 	dateStart int
 	dateEnd   int
 	published bool
+}
+
+func TestArtworkSearchFullViewComposesCanonicalResultsWorkflow(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "artistone000001", "Artist One")
+	for index, title := range []string{"Alpha Work", "Bravo Work", "Charlie Work"} {
+		saveSearchArtwork(t, app, searchArtworkSeed{
+			id:        workID(fmt.Sprintf("compose%d", index)),
+			title:     title,
+			authors:   []string{"artistone000001"},
+			sourceRow: index + 1,
+			published: true,
+		})
+	}
+
+	values := neturl.Values{
+		"dir":  {"desc"},
+		"page": {"2"},
+		"q":    {"Work"},
+		"sort": {"title"},
+		"view": {"list"},
+	}
+	resultsContext, err := buildArtworkSearchResultsViewContext(context.Background(), app, values, 2, 2, requestprotection.Checkpoint)
+	if err != nil {
+		t.Fatalf("build results workflow: %v", err)
+	}
+	full, canonical, err := buildArtworkSearchViewContext(context.Background(), app, values, 2, 2, requestprotection.Checkpoint)
+	if err != nil {
+		t.Fatalf("build full view: %v", err)
+	}
+
+	if canonical != resultsContext.canonical {
+		t.Fatalf("full canonical = %q, results canonical = %q", canonical, resultsContext.canonical)
+	}
+	if !reflect.DeepEqual(full.Results, resultsContext.view) {
+		t.Fatalf("full results differ from canonical results workflow:\nfull: %#v\nresults: %#v", full.Results, resultsContext.view)
+	}
+	if resultsContext.view.ResultCount != 3 {
+		t.Fatalf("result count = %d, want 3", resultsContext.view.ResultCount)
+	}
+	if len(resultsContext.view.Artworks) != 1 || resultsContext.view.Artworks[0].Title != "Alpha Work" {
+		t.Fatalf("second descending page = %#v, want Alpha Work", resultsContext.view.Artworks)
+	}
+	if resultsContext.view.Pagination == "" {
+		t.Fatal("results workflow omitted pagination")
+	}
 }
 
 func saveSearchTaxonomy(t *testing.T, app *pocketbase.PocketBase, collection string, id string, slug string, name string) {

--- a/internal/handlers/artworks/search_integration_test.go
+++ b/internal/handlers/artworks/search_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	neturl "net/url"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/blackfyre/wga/internal/assets/templ/pages"
 	"github.com/blackfyre/wga/internal/config"
+	"github.com/blackfyre/wga/internal/repositories"
 	"github.com/blackfyre/wga/internal/requestprotection"
 	apputils "github.com/blackfyre/wga/internal/utils"
 	"github.com/pocketbase/dbx"
@@ -777,6 +779,80 @@ func TestArtworkSearchRevalidatesPageBeforeHydration(t *testing.T) {
 	}
 	if result.view.ResultCount != 0 || len(result.view.Artworks) != 0 {
 		t.Fatalf("revalidated result = count %d, artworks %#v; want current empty result", result.view.ResultCount, result.view.Artworks)
+	}
+}
+
+func TestArtworkSearchRetriesWhenSortOrderChangesDuringHydration(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "sortartist00001", "Sort Artist")
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id: "sortalpha000001", title: "Alpha Work",
+		authors: []string{"sortartist00001"}, year: 1500, published: true,
+	})
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id: "sortbravo000001", title: "Bravo Work",
+		authors: []string{"sortartist00001"}, year: 1500, published: true,
+	})
+
+	var changed atomic.Bool
+	checkpoint := func(_ context.Context, name string) error {
+		if name != "artworks.search.records" || !changed.CompareAndSwap(false, true) {
+			return nil
+		}
+		record, err := app.FindRecordById("artworks", "sortalpha000001")
+		if err != nil {
+			return err
+		}
+		record.Set("title", "Zulu Work")
+		if err := app.Save(record); err != nil {
+			return err
+		}
+		repositories.AdvanceArtworkCatalogueRevision(app)
+		return nil
+	}
+
+	result, err := buildArtworkSearchResultsViewContext(
+		context.Background(),
+		app,
+		neturl.Values{"sort": {sortTitle}},
+		1,
+		1,
+		checkpoint,
+	)
+	if err != nil {
+		t.Fatalf("build search results: %v", err)
+	}
+	if len(result.view.Artworks) != 1 || result.view.Artworks[0].Id != "sortbravo000001" {
+		t.Fatalf("revalidated artworks = %#v, want Bravo Work", result.view.Artworks)
+	}
+}
+
+func TestArtworkSearchMaximumPageClampsToCanonicalLastPage(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "maxpageartist01", "Maximum Page Artist")
+	for i, title := range []string{"Alpha Work", "Bravo Work", "Charlie Work"} {
+		saveSearchArtwork(t, app, searchArtworkSeed{
+			id: fmt.Sprintf("maxpagework%04d", i), title: title,
+			authors: []string{"maxpageartist01"}, year: 1500, published: true,
+		})
+	}
+
+	result, err := buildArtworkSearchResultsViewContext(
+		context.Background(),
+		app,
+		neturl.Values{"sort": {sortTitle}},
+		math.MaxInt,
+		2,
+		requestprotection.Checkpoint,
+	)
+	if err != nil {
+		t.Fatalf("build maximum-page results: %v", err)
+	}
+	if len(result.view.Artworks) != 1 || result.view.Artworks[0].Title != "Charlie Work" {
+		t.Fatalf("last-page artworks = %#v, want Charlie Work", result.view.Artworks)
+	}
+	if result.canonical != "/artworks?page=2&sort=title" {
+		t.Fatalf("canonical = %q, want final page", result.canonical)
 	}
 }
 

--- a/internal/handlers/artworks/search_integration_test.go
+++ b/internal/handlers/artworks/search_integration_test.go
@@ -3,6 +3,7 @@ package artworks
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -712,6 +713,73 @@ func TestBuildArtworkSearchViewClampsOutOfRangePage(t *testing.T) {
 	}
 }
 
+func TestArtworkPageCountUsesDistinctArtworkIDsAcrossMatchingAuthors(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "alphaartist0001", "Alpha Artist")
+	saveSearchArtist(t, app, "betaartist00001", "Beta Artist")
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id: "sharedwork00001", title: "Shared Work",
+		authors: []string{"alphaartist0001", "betaartist00001"}, year: 1500, published: true,
+	})
+
+	collection, err := app.FindCollectionByNameOrId("artworks")
+	if err != nil {
+		t.Fatalf("find artworks: %v", err)
+	}
+	f := &filters{Query: "Artist", Sort: sortCatalogue, SortDir: sortAsc}
+	rows, err := listArtworkPageRowsForCollection(app, collection, f, 1, 0)
+	if err != nil {
+		t.Fatalf("list artwork page rows: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "sharedwork00001" || rows[0].Total != 1 {
+		t.Fatalf("rows = %#v, want the sole artwork with total 1", rows)
+	}
+
+	result, err := buildArtworkSearchResultsViewContext(context.Background(), app, neturl.Values{"q": {"Artist"}}, 2, 1, requestprotection.Checkpoint)
+	if err != nil {
+		t.Fatalf("build out-of-range results: %v", err)
+	}
+	if result.view.ResultCount != 1 || len(result.view.Artworks) != 1 || result.view.Artworks[0].Id != "sharedwork00001" {
+		t.Fatalf("out-of-range result = count %d, artworks %#v; want the sole distinct artwork", result.view.ResultCount, result.view.Artworks)
+	}
+}
+
+func TestArtworkSearchRevalidatesPageBeforeHydration(t *testing.T) {
+	app := newArtworkSearchApp(t)
+	saveSearchArtist(t, app, "snapshotartist1", "Snapshot Artist")
+	saveSearchArtwork(t, app, searchArtworkSeed{
+		id: "snapshotwork001", title: "Snapshot Work",
+		authors: []string{"snapshotartist1"}, year: 1500, published: true,
+	})
+
+	deleted := make(chan error, 1)
+	checkpoint := func(_ context.Context, name string) error {
+		if name != "artworks.search.records" {
+			return nil
+		}
+		go func() {
+			_, err := app.ConcurrentDB().NewQuery("DELETE FROM artworks WHERE id = {:id}").
+				Bind(dbx.Params{"id": "snapshotwork001"}).
+				Execute()
+			deleted <- err
+		}()
+		select {
+		case err := <-deleted:
+			return err
+		case <-time.After(5 * time.Second):
+			return errors.New("concurrent artwork delete did not complete")
+		}
+	}
+
+	result, err := buildArtworkSearchResultsViewContext(context.Background(), app, neturl.Values{}, 1, 16, checkpoint)
+	if err != nil {
+		t.Fatalf("build search results: %v", err)
+	}
+	if result.view.ResultCount != 0 || len(result.view.Artworks) != 0 {
+		t.Fatalf("revalidated result = count %d, artworks %#v; want current empty result", result.view.ResultCount, result.view.Artworks)
+	}
+}
+
 func TestBuildArtworkSearchViewIssuesBoundedQueries(t *testing.T) {
 	small := newArtworkSearchApp(t)
 	saveSearchArtist(t, small, "artistone000001", "Artist One")
@@ -750,6 +818,24 @@ func TestBuildArtworkSearchViewIssuesBoundedQueries(t *testing.T) {
 	}
 	if smallCount != largeCount {
 		t.Errorf("query count grew with artwork count: %d (5 artworks) vs %d (60 artworks)", smallCount, largeCount)
+	}
+
+	firstPageCount, err := countSearchQueries(large, func() error {
+		_, err := buildArtworkSearchResultsViewContext(context.Background(), large, neturl.Values{}, 1, 16, requestprotection.Checkpoint)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("first-page results build: %v", err)
+	}
+	outOfRangeCount, err := countSearchQueries(large, func() error {
+		_, err := buildArtworkSearchResultsViewContext(context.Background(), large, neturl.Values{}, 999, 16, requestprotection.Checkpoint)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("out-of-range results build: %v", err)
+	}
+	if outOfRangeCount != firstPageCount+1 {
+		t.Errorf("out-of-range query count = %d, want one recovery statement beyond first-page count %d", outOfRangeCount, firstPageCount)
 	}
 }
 

--- a/internal/handlers/artworks/task71_search_integration_test.go
+++ b/internal/handlers/artworks/task71_search_integration_test.go
@@ -60,6 +60,35 @@ func TestTask71VenueFiltersAndPublishedHoldingCounts(t *testing.T) {
 	}
 }
 
+func TestCollectionHoldingsProjectionPreservesEmptyVenueOutputs(t *testing.T) {
+	t.Run("no locations", func(t *testing.T) {
+		app := newArtworkSearchApp(t)
+		options, err := getVenueOptions(app, "", "")
+		if err != nil {
+			t.Fatalf("venue options: %v", err)
+		}
+		if len(options.entries) != 0 || options.totalOptions != 0 || options.totalHoldings != 0 {
+			t.Fatalf("empty venue options = %#v", options)
+		}
+	})
+
+	t.Run("selected location without eligible holdings", func(t *testing.T) {
+		app := newArtworkSearchApp(t)
+		saveSearchLocation(t, app, "loctaskempty001", "Empty Museum")
+
+		options, err := getVenueOptions(app, "", "loctaskempty001")
+		if err != nil {
+			t.Fatalf("venue options: %v", err)
+		}
+		if len(options.entries) != 1 || options.entries[0] != (venueOption{value: "loctaskempty001", label: "Empty Museum"}) {
+			t.Fatalf("selected zero-count location = %#v", options.entries)
+		}
+		if options.totalOptions != 0 || options.totalHoldings != 0 || options.omittedOptions != 0 || options.omittedHoldings != 0 {
+			t.Fatalf("selected zero-count totals = %#v", options)
+		}
+	})
+}
+
 func TestTask71VenueFacetIsBoundedAndQueryCountStable(t *testing.T) {
 	app := newArtworkSearchApp(t)
 	saveSearchArtist(t, app, "artisttask71002", "Task Artist")

--- a/internal/handlers/artworks/task71_search_integration_test.go
+++ b/internal/handlers/artworks/task71_search_integration_test.go
@@ -137,6 +137,25 @@ func TestTask71VenueFacetTieOrderAndHonestOmittedHoldingsNote(t *testing.T) {
 	}
 }
 
+func TestSQLiteNoCaseCompareMatchesASCIIOrdering(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		left, right string
+		want        int
+	}{
+		{name: "case insensitive equality", left: "Alpha", right: "alpha", want: 0},
+		{name: "folded order", left: "beta", right: "Gamma", want: -1},
+		{name: "prefix", left: "Museum", right: "Museum Two", want: -1},
+		{name: "non ASCII remains byte ordered", left: "Á", right: "É", want: -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sqliteNoCaseCompare(tc.left, tc.right); got != tc.want {
+				t.Fatalf("sqliteNoCaseCompare(%q, %q) = %d, want %d", tc.left, tc.right, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestTask71RouteFullHtmxAndOrdinaryGETParity(t *testing.T) {
 	app := newArtworkSearchApp(t)
 	saveSearchArtist(t, app, "artisttask71004", "Task Artist")

--- a/internal/handlers/artworks/task71_search_integration_test.go
+++ b/internal/handlers/artworks/task71_search_integration_test.go
@@ -156,6 +156,12 @@ func TestSQLiteNoCaseCompareMatchesASCIIOrdering(t *testing.T) {
 	}
 }
 
+func TestVenueNameMatchesQueryFoldsUnicodeCase(t *testing.T) {
+	if !venueNameMatchesQuery("Óbuda Museum", "óbuda") {
+		t.Fatal("expected collection-name search to match Unicode case variants")
+	}
+}
+
 func TestTask71RouteFullHtmxAndOrdinaryGETParity(t *testing.T) {
 	app := newArtworkSearchApp(t)
 	saveSearchArtist(t, app, "artisttask71004", "Task Artist")

--- a/internal/hooks/artworks.go
+++ b/internal/hooks/artworks.go
@@ -1,0 +1,18 @@
+package hooks
+
+import (
+	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/repositories"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func artworkAvailabilityCacheHook(app core.App) {
+	invalidate := func(e *core.RecordEvent) error {
+		repositories.InvalidateArtistAvailability(e.App)
+		return e.Next()
+	}
+
+	app.OnRecordAfterCreateSuccess(constants.CollectionArtworks).BindFunc(invalidate)
+	app.OnRecordAfterUpdateSuccess(constants.CollectionArtworks).BindFunc(invalidate)
+	app.OnRecordAfterDeleteSuccess(constants.CollectionArtworks).BindFunc(invalidate)
+}

--- a/internal/hooks/artworks.go
+++ b/internal/hooks/artworks.go
@@ -8,6 +8,7 @@ import (
 
 func artworkCatalogueCacheHook(app core.App) {
 	invalidate := func(e *core.RecordEvent) error {
+		repositories.AdvanceArtworkCatalogueRevision(e.App)
 		repositories.InvalidateArtistAvailability(e.App)
 		repositories.InvalidateCollectionHoldings(e.App)
 		return e.Next()

--- a/internal/hooks/artworks.go
+++ b/internal/hooks/artworks.go
@@ -6,9 +6,10 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 )
 
-func artworkAvailabilityCacheHook(app core.App) {
+func artworkCatalogueCacheHook(app core.App) {
 	invalidate := func(e *core.RecordEvent) error {
 		repositories.InvalidateArtistAvailability(e.App)
+		repositories.InvalidateCollectionHoldings(e.App)
 		return e.Next()
 	}
 

--- a/internal/hooks/artworks_test.go
+++ b/internal/hooks/artworks_test.go
@@ -40,7 +40,7 @@ func TestArtworkAvailabilityCacheHookInvalidatesAfterMutations(t *testing.T) {
 		t.Fatalf("save artworks collection: %v", err)
 	}
 
-	artworkAvailabilityCacheHook(app)
+	artworkCatalogueCacheHook(app)
 
 	artist := core.NewRecord(artists)
 	artist.Id = "hookartist00001"

--- a/internal/hooks/artworks_test.go
+++ b/internal/hooks/artworks_test.go
@@ -60,14 +60,22 @@ func TestArtworkAvailabilityCacheHookInvalidatesAfterMutations(t *testing.T) {
 	artwork.Set("title", "Hook Work")
 	artwork.Set("author", []string{artist.Id})
 	artwork.Set("published", true)
+	revision := repositories.ArtworkCatalogueRevision(app)
 	if err := app.Save(artwork); err != nil {
 		t.Fatalf("save artwork: %v", err)
+	}
+	if got := repositories.ArtworkCatalogueRevision(app); got != revision+1 {
+		t.Fatalf("catalogue revision after create = %d, want %d", got, revision+1)
 	}
 	assertHookArtistAvailability(t, repo, true)
 
 	artwork.Set("published", false)
+	revision = repositories.ArtworkCatalogueRevision(app)
 	if err := app.Save(artwork); err != nil {
 		t.Fatalf("unpublish artwork: %v", err)
+	}
+	if got := repositories.ArtworkCatalogueRevision(app); got != revision+1 {
+		t.Fatalf("catalogue revision after update = %d, want %d", got, revision+1)
 	}
 	assertHookArtistAvailability(t, repo, false)
 

--- a/internal/hooks/artworks_test.go
+++ b/internal/hooks/artworks_test.go
@@ -1,0 +1,98 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/blackfyre/wga/internal/repositories"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func TestArtworkAvailabilityCacheHookInvalidatesAfterMutations(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	artists := core.NewBaseCollection("artists")
+	artists.Id = "hook_artists"
+	artists.MarkAsNew()
+	artists.Fields.Add(
+		&core.TextField{Id: "artist_name", Name: "name", Required: true},
+		&core.TextField{Id: "artist_filing", Name: "filing_name"},
+		&core.TextField{Id: "artist_short", Name: "short_name"},
+		&core.BoolField{Id: "artist_published", Name: "published"},
+	)
+	if err := app.Save(artists); err != nil {
+		t.Fatalf("save artists collection: %v", err)
+	}
+
+	artworks := core.NewBaseCollection("artworks")
+	artworks.Id = "hook_artworks"
+	artworks.MarkAsNew()
+	artworks.Fields.Add(
+		&core.TextField{Id: "artwork_title", Name: "title", Required: true},
+		&core.RelationField{Id: "artwork_author", Name: "author", CollectionId: artists.Id, MinSelect: 1, MaxSelect: 10},
+		&core.BoolField{Id: "artwork_published", Name: "published"},
+	)
+	if err := app.Save(artworks); err != nil {
+		t.Fatalf("save artworks collection: %v", err)
+	}
+
+	artworkAvailabilityCacheHook(app)
+
+	artist := core.NewRecord(artists)
+	artist.Id = "hookartist00001"
+	artist.Set("name", "Hook Artist")
+	artist.Set("filing_name", "Hook Artist")
+	artist.Set("short_name", "Hook Artist")
+	artist.Set("published", true)
+	if err := app.Save(artist); err != nil {
+		t.Fatalf("save artist: %v", err)
+	}
+
+	repo := repositories.NewArtistIndexRepository(app)
+	assertHookArtistAvailability(t, repo, false)
+
+	artwork := core.NewRecord(artworks)
+	artwork.Id = "hookartwork0001"
+	artwork.Set("title", "Hook Work")
+	artwork.Set("author", []string{artist.Id})
+	artwork.Set("published", true)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("save artwork: %v", err)
+	}
+	assertHookArtistAvailability(t, repo, true)
+
+	artwork.Set("published", false)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("unpublish artwork: %v", err)
+	}
+	assertHookArtistAvailability(t, repo, false)
+
+	artwork.Set("published", true)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("republish artwork: %v", err)
+	}
+	assertHookArtistAvailability(t, repo, true)
+
+	if err := app.Delete(artwork); err != nil {
+		t.Fatalf("delete artwork: %v", err)
+	}
+	assertHookArtistAvailability(t, repo, false)
+}
+
+func assertHookArtistAvailability(t *testing.T, repo *repositories.ArtistIndexRepository, want bool) {
+	t.Helper()
+	artists, err := repo.ListArtists(repositories.ArtistIndexFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("list artists: %v", err)
+	}
+	if len(artists) != 1 {
+		t.Fatalf("artists = %d, want 1", len(artists))
+	}
+	if artists[0].Available != want {
+		t.Fatalf("availability = %t, want %t", artists[0].Available, want)
+	}
+}

--- a/internal/hooks/collection_holdings.go
+++ b/internal/hooks/collection_holdings.go
@@ -1,0 +1,20 @@
+package hooks
+
+import (
+	"github.com/blackfyre/wga/internal/constants"
+	"github.com/blackfyre/wga/internal/repositories"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func collectionHoldingsCacheHook(app core.App) {
+	invalidate := func(e *core.RecordEvent) error {
+		repositories.InvalidateCollectionHoldings(e.App)
+		return e.Next()
+	}
+
+	for _, collection := range []string{constants.CollectionLocations, constants.CollectionArtists} {
+		app.OnRecordAfterCreateSuccess(collection).BindFunc(invalidate)
+		app.OnRecordAfterUpdateSuccess(collection).BindFunc(invalidate)
+		app.OnRecordAfterDeleteSuccess(collection).BindFunc(invalidate)
+	}
+}

--- a/internal/hooks/collection_holdings.go
+++ b/internal/hooks/collection_holdings.go
@@ -17,6 +17,7 @@ func collectionHoldingsCacheHook(app core.App) {
 	app.OnRecordAfterDeleteSuccess(constants.CollectionLocations).BindFunc(invalidateHoldings)
 
 	invalidateArtistProjections := func(e *core.RecordEvent) error {
+		repositories.AdvanceArtworkCatalogueRevision(e.App)
 		repositories.InvalidateCollectionHoldings(e.App)
 		repositories.InvalidateArtistAvailability(e.App)
 		return e.Next()

--- a/internal/hooks/collection_holdings.go
+++ b/internal/hooks/collection_holdings.go
@@ -7,14 +7,21 @@ import (
 )
 
 func collectionHoldingsCacheHook(app core.App) {
-	invalidate := func(e *core.RecordEvent) error {
+	invalidateHoldings := func(e *core.RecordEvent) error {
 		repositories.InvalidateCollectionHoldings(e.App)
 		return e.Next()
 	}
 
-	for _, collection := range []string{constants.CollectionLocations, constants.CollectionArtists} {
-		app.OnRecordAfterCreateSuccess(collection).BindFunc(invalidate)
-		app.OnRecordAfterUpdateSuccess(collection).BindFunc(invalidate)
-		app.OnRecordAfterDeleteSuccess(collection).BindFunc(invalidate)
+	app.OnRecordAfterCreateSuccess(constants.CollectionLocations).BindFunc(invalidateHoldings)
+	app.OnRecordAfterUpdateSuccess(constants.CollectionLocations).BindFunc(invalidateHoldings)
+	app.OnRecordAfterDeleteSuccess(constants.CollectionLocations).BindFunc(invalidateHoldings)
+
+	invalidateArtistProjections := func(e *core.RecordEvent) error {
+		repositories.InvalidateCollectionHoldings(e.App)
+		repositories.InvalidateArtistAvailability(e.App)
+		return e.Next()
 	}
+	app.OnRecordAfterCreateSuccess(constants.CollectionArtists).BindFunc(invalidateArtistProjections)
+	app.OnRecordAfterUpdateSuccess(constants.CollectionArtists).BindFunc(invalidateArtistProjections)
+	app.OnRecordAfterDeleteSuccess(constants.CollectionArtists).BindFunc(invalidateArtistProjections)
 }

--- a/internal/hooks/collection_holdings_test.go
+++ b/internal/hooks/collection_holdings_test.go
@@ -59,8 +59,20 @@ func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
 	artist.Set("filing_name", "Holding Artist")
 	artist.Set("short_name", "Holding Artist")
 	artist.Set("published", true)
+	revision := repositories.ArtworkCatalogueRevision(app)
 	if err := app.Save(artist); err != nil {
 		t.Fatalf("save artist: %v", err)
+	}
+	if got := repositories.ArtworkCatalogueRevision(app); got != revision+1 {
+		t.Fatalf("catalogue revision after artist create = %d, want %d", got, revision+1)
+	}
+	artist.Set("name", "Renamed Holding Artist")
+	revision = repositories.ArtworkCatalogueRevision(app)
+	if err := app.Save(artist); err != nil {
+		t.Fatalf("rename artist: %v", err)
+	}
+	if got := repositories.ArtworkCatalogueRevision(app); got != revision+1 {
+		t.Fatalf("catalogue revision after artist update = %d, want %d", got, revision+1)
 	}
 	location := core.NewRecord(locations)
 	location.Id = "holdingloc00001"

--- a/internal/hooks/collection_holdings_test.go
+++ b/internal/hooks/collection_holdings_test.go
@@ -1,0 +1,150 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/blackfyre/wga/internal/repositories"
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	artists := core.NewBaseCollection("artists")
+	artists.Id = "holding_artists"
+	artists.MarkAsNew()
+	artists.Fields.Add(&core.TextField{Id: "holding_artist_name", Name: "name", Required: true})
+	if err := app.Save(artists); err != nil {
+		t.Fatalf("save artists collection: %v", err)
+	}
+
+	locations := core.NewBaseCollection("locations")
+	locations.Id = "holding_locations"
+	locations.MarkAsNew()
+	locations.Fields.Add(&core.TextField{Id: "holding_location_name", Name: "name", Required: true})
+	if err := app.Save(locations); err != nil {
+		t.Fatalf("save locations collection: %v", err)
+	}
+
+	artworks := core.NewBaseCollection("artworks")
+	artworks.Id = "holding_artworks"
+	artworks.MarkAsNew()
+	artworks.Fields.Add(
+		&core.TextField{Id: "holding_artwork_title", Name: "title", Required: true},
+		&core.RelationField{Id: "holding_artwork_author", Name: "author", CollectionId: artists.Id, MinSelect: 1, MaxSelect: 10},
+		&core.RelationField{Id: "holding_artwork_location", Name: "current_location_id", CollectionId: locations.Id, MaxSelect: 1},
+		&core.BoolField{Id: "holding_artwork_published", Name: "published"},
+	)
+	if err := app.Save(artworks); err != nil {
+		t.Fatalf("save artworks collection: %v", err)
+	}
+
+	artworkCatalogueCacheHook(app)
+	collectionHoldingsCacheHook(app)
+
+	artist := core.NewRecord(artists)
+	artist.Id = "holdingartist01"
+	artist.Set("name", "Holding Artist")
+	if err := app.Save(artist); err != nil {
+		t.Fatalf("save artist: %v", err)
+	}
+	location := core.NewRecord(locations)
+	location.Id = "holdingloc00001"
+	location.Set("name", "Original Museum")
+	if err := app.Save(location); err != nil {
+		t.Fatalf("save location: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Original Museum", 0)
+
+	artwork := core.NewRecord(artworks)
+	artwork.Id = "holdingwork0001"
+	artwork.Set("title", "Holding Work")
+	artwork.Set("author", []string{artist.Id})
+	artwork.Set("current_location_id", location.Id)
+	artwork.Set("published", true)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("save artwork: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Original Museum", 1)
+
+	location.Set("name", "Renamed Museum")
+	if err := app.Save(location); err != nil {
+		t.Fatalf("rename location: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 1)
+
+	artwork.Set("published", false)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("unpublish artwork: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 0)
+	artwork.Set("published", true)
+	if err := app.Save(artwork); err != nil {
+		t.Fatalf("republish artwork: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 1)
+
+	if err := app.Delete(artist); err != nil {
+		t.Fatalf("delete artist: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 0)
+	if _, err := app.DB().NewQuery("UPDATE artworks SET author = {:author} WHERE id = {:id}").Bind(dbx.Params{
+		"author": `["` + artist.Id + `"]`,
+		"id":     artwork.Id,
+	}).Execute(); err != nil {
+		t.Fatalf("restore persisted artwork relation: %v", err)
+	}
+
+	restoredArtist := core.NewRecord(artists)
+	restoredArtist.Id = artist.Id
+	restoredArtist.Set("name", "Restored Artist")
+	if err := app.Save(restoredArtist); err != nil {
+		t.Fatalf("restore artist: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 1)
+
+	if err := app.Delete(artwork); err != nil {
+		t.Fatalf("delete artwork: %v", err)
+	}
+	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 0)
+	if err := app.Delete(location); err != nil {
+		t.Fatalf("delete location: %v", err)
+	}
+	assertCollectionHoldingMissing(t, app, location.Id)
+}
+
+func assertCollectionHolding(t *testing.T, app core.App, id string, label string, count int) {
+	t.Helper()
+	holdings, err := repositories.LoadCollectionHoldings(app)
+	if err != nil {
+		t.Fatalf("load collection holdings: %v", err)
+	}
+	for _, holding := range holdings {
+		if holding.Value == id {
+			if holding.Label != label || holding.Count != count {
+				t.Fatalf("holding = %#v, want label %q and count %d", holding, label, count)
+			}
+			return
+		}
+	}
+	t.Fatalf("holding %q missing from %#v", id, holdings)
+}
+
+func assertCollectionHoldingMissing(t *testing.T, app core.App, id string) {
+	t.Helper()
+	holdings, err := repositories.LoadCollectionHoldings(app)
+	if err != nil {
+		t.Fatalf("load collection holdings: %v", err)
+	}
+	for _, holding := range holdings {
+		if holding.Value == id {
+			t.Fatalf("holding %q remains after delete: %#v", id, holdings)
+		}
+	}
+}

--- a/internal/hooks/collection_holdings_test.go
+++ b/internal/hooks/collection_holdings_test.go
@@ -20,6 +20,11 @@ func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
 	artists.Id = "holding_artists"
 	artists.MarkAsNew()
 	artists.Fields.Add(&core.TextField{Id: "holding_artist_name", Name: "name", Required: true})
+	artists.Fields.Add(
+		&core.TextField{Id: "holding_artist_filing", Name: "filing_name"},
+		&core.TextField{Id: "holding_artist_short", Name: "short_name"},
+		&core.BoolField{Id: "holding_artist_published", Name: "published"},
+	)
 	if err := app.Save(artists); err != nil {
 		t.Fatalf("save artists collection: %v", err)
 	}
@@ -51,6 +56,9 @@ func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
 	artist := core.NewRecord(artists)
 	artist.Id = "holdingartist01"
 	artist.Set("name", "Holding Artist")
+	artist.Set("filing_name", "Holding Artist")
+	artist.Set("short_name", "Holding Artist")
+	artist.Set("published", true)
 	if err := app.Save(artist); err != nil {
 		t.Fatalf("save artist: %v", err)
 	}
@@ -78,6 +86,8 @@ func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
 		t.Fatalf("rename location: %v", err)
 	}
 	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 1)
+	repo := repositories.NewArtistIndexRepository(app)
+	assertHookArtistAvailability(t, repo, true)
 
 	artwork.Set("published", false)
 	if err := app.Save(artwork); err != nil {
@@ -94,18 +104,22 @@ func TestCollectionHoldingsCacheHooksInvalidateAfterMutations(t *testing.T) {
 		t.Fatalf("delete artist: %v", err)
 	}
 	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 0)
+	restoredArtist := core.NewRecord(artists)
+	restoredArtist.Id = artist.Id
+	restoredArtist.Set("name", "Restored Artist")
+	restoredArtist.Set("filing_name", "Restored Artist")
+	restoredArtist.Set("short_name", "Restored Artist")
+	restoredArtist.Set("published", true)
+	if err := app.Save(restoredArtist); err != nil {
+		t.Fatalf("restore artist: %v", err)
+	}
+	assertHookArtistAvailability(t, repo, false)
+
 	if _, err := app.DB().NewQuery("UPDATE artworks SET author = {:author} WHERE id = {:id}").Bind(dbx.Params{
 		"author": `["` + artist.Id + `"]`,
 		"id":     artwork.Id,
 	}).Execute(); err != nil {
 		t.Fatalf("restore persisted artwork relation: %v", err)
-	}
-
-	restoredArtist := core.NewRecord(artists)
-	restoredArtist.Id = artist.Id
-	restoredArtist.Set("name", "Restored Artist")
-	if err := app.Save(restoredArtist); err != nil {
-		t.Fatalf("restore artist: %v", err)
 	}
 	assertCollectionHolding(t, app, location.Id, "Renamed Museum", 1)
 

--- a/internal/hooks/main.go
+++ b/internal/hooks/main.go
@@ -6,5 +6,6 @@ func RegisterHooks(app core.App) {
 	app.Logger().Debug("Registering hooks...")
 	fileDownloadHook(app)
 	guestbookYearsCacheHook(app)
-	artworkAvailabilityCacheHook(app)
+	artworkCatalogueCacheHook(app)
+	collectionHoldingsCacheHook(app)
 }

--- a/internal/hooks/main.go
+++ b/internal/hooks/main.go
@@ -6,4 +6,5 @@ func RegisterHooks(app core.App) {
 	app.Logger().Debug("Registering hooks...")
 	fileDownloadHook(app)
 	guestbookYearsCacheHook(app)
+	artworkAvailabilityCacheHook(app)
 }

--- a/internal/migrations/1788998400_add_artist_query_indexes.go
+++ b/internal/migrations/1788998400_add_artist_query_indexes.go
@@ -1,0 +1,47 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+const (
+	artistIndexPublishedFiling     = "pbx_artist_published_filing"
+	artistIndexPublishedFilingDesc = "pbx_artist_published_filing_desc"
+	artistIndexPublishedBirth      = "pbx_artist_published_birth"
+)
+
+var artistQueryIndexes = []string{
+	"CREATE INDEX `" + artistIndexPublishedFiling + "` ON `Artists` (`published`, `filing_name`, `id`)",
+	"CREATE INDEX `" + artistIndexPublishedFilingDesc + "` ON `Artists` (`published`, `filing_name` DESC, `id` ASC)",
+	"CREATE INDEX `" + artistIndexPublishedBirth + "` ON `Artists` (`published`, (`year_of_birth` = 0), `year_of_birth`, `filing_name`, `id`)",
+}
+
+func init() {
+	m.Register(addArtistQueryIndexes, removeArtistQueryIndexes)
+}
+
+func addArtistQueryIndexes(app core.App) error {
+	artists, err := app.FindCollectionByNameOrId("artists")
+	if err != nil {
+		return err
+	}
+	for _, index := range artistQueryIndexes {
+		artists.Indexes = appendIndex(artists.Indexes, index)
+	}
+	return app.Save(artists)
+}
+
+func removeArtistQueryIndexes(app core.App) error {
+	artists, err := app.FindCollectionByNameOrId("artists")
+	if err != nil {
+		return err
+	}
+	artists.Indexes = removeIndex(
+		artists.Indexes,
+		artistIndexPublishedFiling,
+		artistIndexPublishedFilingDesc,
+		artistIndexPublishedBirth,
+	)
+	return app.Save(artists)
+}

--- a/internal/migrations/artist_query_indexes_test.go
+++ b/internal/migrations/artist_query_indexes_test.go
@@ -1,0 +1,131 @@
+package migrations
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+func TestArtistQueryIndexesMigrationLifecycle(t *testing.T) {
+	app := newMigrationTestApp(t, t.TempDir())
+	t.Cleanup(func() {
+		if err := app.ResetBootstrapState(); err != nil {
+			t.Error(err)
+		}
+	})
+
+	if err := createCurrentSchema(app); err != nil {
+		t.Fatalf("create baseline schema: %v", err)
+	}
+	if err := addArtistIdentityFields(app); err != nil {
+		t.Fatalf("add artist identity fields: %v", err)
+	}
+
+	artists, err := app.FindCollectionByNameOrId("artists")
+	if err != nil {
+		t.Fatalf("find artists: %v", err)
+	}
+	record := core.NewRecord(artists)
+	record.Id = "indexartist0001"
+	record.Set("name", "Index Artist")
+	record.Set("slug", "index-artist")
+	record.Set("filing_name", "Artist, Index")
+	record.Set("short_name", "Index Artist")
+	record.Set("known_place_of_birth", "n/a")
+	record.Set("known_place_of_death", "n/a")
+	record.Set("published", true)
+	if err := app.Save(record); err != nil {
+		t.Fatalf("save existing artist: %v", err)
+	}
+
+	if err := addArtistQueryIndexes(app); err != nil {
+		t.Fatalf("add artist query indexes: %v", err)
+	}
+	if err := addArtistQueryIndexes(app); err != nil {
+		t.Fatalf("add artist query indexes again: %v", err)
+	}
+
+	artists, err = app.FindCollectionByNameOrId("artists")
+	if err != nil {
+		t.Fatalf("reload artists: %v", err)
+	}
+	for _, expected := range artistQueryIndexes {
+		if countExact(artists.Indexes, expected) != 1 {
+			t.Fatalf("index definition count for %q = %d, want 1 in %#v", expected, countExact(artists.Indexes, expected), artists.Indexes)
+		}
+	}
+	assertPhysicalArtistIndexes(t, app, true)
+	assertIndexArtistPreserved(t, app, record.Id)
+
+	if err := removeArtistQueryIndexes(app); err != nil {
+		t.Fatalf("remove artist query indexes: %v", err)
+	}
+	artists, err = app.FindCollectionByNameOrId("artists")
+	if err != nil {
+		t.Fatalf("reload rolled-back artists: %v", err)
+	}
+	for _, removed := range artistQueryIndexes {
+		if slices.Contains(artists.Indexes, removed) {
+			t.Fatalf("rollback retained index %q", removed)
+		}
+	}
+	for _, baseline := range []string{"pbx_artist_slug", "pbx_artist_published_name"} {
+		if !containsIndexName(artists.Indexes, baseline) {
+			t.Fatalf("rollback removed baseline index %q from %#v", baseline, artists.Indexes)
+		}
+	}
+	assertPhysicalArtistIndexes(t, app, false)
+	assertIndexArtistPreserved(t, app, record.Id)
+}
+
+func countExact(values []string, wanted string) int {
+	count := 0
+	for _, value := range values {
+		if value == wanted {
+			count++
+		}
+	}
+	return count
+}
+
+func containsIndexName(indexes []string, name string) bool {
+	for _, index := range indexes {
+		if strings.Contains(index, "`"+name+"`") {
+			return true
+		}
+	}
+	return false
+}
+
+func assertPhysicalArtistIndexes(t *testing.T, app core.App, want bool) {
+	t.Helper()
+	rows := []struct {
+		Name string `db:"name"`
+	}{}
+	if err := app.DB().NewQuery("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'Artists'").All(&rows); err != nil {
+		t.Fatalf("list physical artist indexes: %v", err)
+	}
+	names := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		names[row.Name] = struct{}{}
+	}
+	for _, name := range []string{artistIndexPublishedFiling, artistIndexPublishedFilingDesc, artistIndexPublishedBirth} {
+		_, found := names[name]
+		if found != want {
+			t.Fatalf("physical index %q present = %t, want %t; indexes = %#v", name, found, want, names)
+		}
+	}
+}
+
+func assertIndexArtistPreserved(t *testing.T, app core.App, id string) {
+	t.Helper()
+	record, err := app.FindRecordById("artists", id)
+	if err != nil {
+		t.Fatalf("find existing artist after migration transition: %v", err)
+	}
+	if record.GetString("filing_name") != "Artist, Index" || record.GetString("short_name") != "Index Artist" || !record.GetBool("published") {
+		t.Fatalf("existing artist changed: %#v", record)
+	}
+}

--- a/internal/migrations/artist_query_indexes_test.go
+++ b/internal/migrations/artist_query_indexes_test.go
@@ -57,6 +57,18 @@ func TestArtistQueryIndexesMigrationLifecycle(t *testing.T) {
 		}
 	}
 	assertPhysicalArtistIndexes(t, app, true)
+	assertArtistQueryPlanUsesIndex(t, app,
+		"filing_name ASC, id ASC",
+		artistIndexPublishedFiling,
+	)
+	assertArtistQueryPlanUsesIndex(t, app,
+		"filing_name DESC, id ASC",
+		artistIndexPublishedFilingDesc,
+	)
+	assertArtistQueryPlanUsesIndex(t, app,
+		"(year_of_birth = 0) ASC, year_of_birth ASC, filing_name ASC, id ASC",
+		artistIndexPublishedBirth,
+	)
 	assertIndexArtistPreserved(t, app, record.Id)
 
 	if err := removeArtistQueryIndexes(app); err != nil {
@@ -116,6 +128,35 @@ func assertPhysicalArtistIndexes(t *testing.T, app core.App, want bool) {
 		if found != want {
 			t.Fatalf("physical index %q present = %t, want %t; indexes = %#v", name, found, want, names)
 		}
+	}
+}
+
+func assertArtistQueryPlanUsesIndex(t *testing.T, app core.App, orderBy string, index string) {
+	t.Helper()
+	rows := []struct {
+		Detail string `db:"detail"`
+	}{}
+	query := `EXPLAIN QUERY PLAN
+		SELECT Artists.*
+		FROM Artists
+		WHERE published = true
+			AND filing_name IS NOT NULL AND TRIM(filing_name) != ''
+			AND short_name IS NOT NULL AND TRIM(short_name) != ''
+		ORDER BY ` + orderBy + `
+		LIMIT 60 OFFSET 0`
+	if err := app.DB().NewQuery(query).All(&rows); err != nil {
+		t.Fatalf("explain artist order %q: %v", orderBy, err)
+	}
+	details := make([]string, 0, len(rows))
+	for _, row := range rows {
+		details = append(details, row.Detail)
+	}
+	plan := strings.Join(details, "\n")
+	if !strings.Contains(plan, "USING INDEX "+index) {
+		t.Fatalf("artist order %q plan = %q, want index %q", orderBy, plan, index)
+	}
+	if strings.Contains(plan, "TEMP B-TREE") {
+		t.Fatalf("artist order %q retained temporary sort: %q", orderBy, plan)
 	}
 }
 

--- a/internal/repositories/artist_index.go
+++ b/internal/repositories/artist_index.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"errors"
 	"sort"
-	"strconv"
 	"strings"
 
+	"github.com/blackfyre/wga/internal/utils"
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -16,6 +16,10 @@ import (
 // fields (filing and short form) must be present. Prior-bootstrap records carry
 // blank filing/short fields and are denied rather than reconstructed.
 const publishedArtistIdentity = "filing_name IS NOT NULL AND TRIM(filing_name) != '' AND short_name IS NOT NULL AND TRIM(short_name) != ''"
+
+const artistAvailabilityCacheKey = "artists:index:published-artwork-authors"
+
+type artistAvailabilitySet map[string]struct{}
 
 // filingInitialFold maps the non-ASCII producer filing initials present in the
 // supplied dataset to their ASCII navigation letter. Navigation only: the
@@ -152,18 +156,15 @@ func (r *ArtistIndexRepository) ListArtists(filter ArtistIndexFilter) ([]Indexed
 		return nil, nil
 	}
 
-	ids := make([]string, len(records))
-	for i, record := range records {
-		ids[i] = record.Id
-	}
-	available, err := r.publishedArtworkAuthorIDs(ids)
+	available, err := r.publishedArtworkAuthorIDs()
 	if err != nil {
 		return nil, err
 	}
 
 	result := make([]IndexedArtist, len(records))
 	for i, record := range records {
-		result[i] = IndexedArtist{Record: record, Available: available[record.Id]}
+		_, hasPublishedArtwork := available[record.Id]
+		result[i] = IndexedArtist{Record: record, Available: hasPublishedArtwork}
 	}
 
 	return result, nil
@@ -308,40 +309,29 @@ func filingLetterExpression(letter string) dbx.Expression {
 	return dbx.Or(exprs...)
 }
 
-// publishedArtworkAuthorIDs returns the subset of candidateIDs that have at least
-// one published artwork. It runs a single bound aggregate query; an empty
-// candidate set returns an empty result without querying.
-func (r *ArtistIndexRepository) publishedArtworkAuthorIDs(candidateIDs []string) (map[string]bool, error) {
-	available := map[string]bool{}
-	if len(candidateIDs) == 0 {
+// publishedArtworkAuthorIDs returns the complete application-scoped set of
+// artists referenced anywhere in published artwork author relations. Each cache
+// generation performs the catalogue-wide expansion once; bounded artist pages
+// then resolve availability by intersecting their records with this set.
+func (r *ArtistIndexRepository) publishedArtworkAuthorIDs() (artistAvailabilitySet, error) {
+	return utils.GetOrLoadCachedValue(r.app, artistAvailabilityCacheKey, 0, func() (artistAvailabilitySet, error) {
+		rows := []struct {
+			AuthorID string `db:"author_id"`
+		}{}
+		if err := r.app.DB().NewQuery(`
+			SELECT DISTINCT je.value AS author_id
+			FROM Artworks
+			CROSS JOIN json_each(Artworks.author) je
+			WHERE Artworks.published IS true AND je.value != ''
+		`).All(&rows); err != nil {
+			return nil, err
+		}
+
+		available := make(artistAvailabilitySet, len(rows))
+		for _, row := range rows {
+			available[row.AuthorID] = struct{}{}
+		}
+
 		return available, nil
-	}
-
-	placeholders := make([]string, len(candidateIDs))
-	params := dbx.Params{}
-	for i, id := range candidateIDs {
-		key := "artist_id_" + strconv.Itoa(i)
-		placeholders[i] = "{:" + key + "}"
-		params[key] = id
-	}
-
-	rows := []struct {
-		AuthorID string `db:"author_id"`
-	}{}
-	query := `
-		SELECT DISTINCT je.value AS author_id
-		FROM Artworks
-		CROSS JOIN json_each(Artworks.author) je
-		WHERE Artworks.published IS true
-		  AND je.value IN (` + strings.Join(placeholders, ", ") + `)
-	`
-	if err := r.app.DB().NewQuery(query).Bind(params).All(&rows); err != nil {
-		return nil, err
-	}
-
-	for _, row := range rows {
-		available[row.AuthorID] = true
-	}
-
-	return available, nil
+	})
 }

--- a/internal/repositories/artist_index.go
+++ b/internal/repositories/artist_index.go
@@ -82,11 +82,23 @@ type IndexedArtist struct {
 
 // ArtistIndexRepository is the bounded read-model for the public artist index.
 type ArtistIndexRepository struct {
-	app core.App
+	app                    core.App
+	loadArtistAvailability func() (artistAvailabilitySet, error)
 }
 
 func NewArtistIndexRepository(app core.App) *ArtistIndexRepository {
-	return &ArtistIndexRepository{app: app}
+	return &ArtistIndexRepository{
+		app: app,
+		loadArtistAvailability: func() (artistAvailabilitySet, error) {
+			return loadPublishedArtworkAuthorIDs(app)
+		},
+	}
+}
+
+// InvalidateArtistAvailability advances the projection generation so the next
+// lookup observes current persisted artwork relations.
+func InvalidateArtistAvailability(app core.App) {
+	utils.DeleteCachedValue(app, artistAvailabilityCacheKey)
 }
 
 // CountArtists returns the number of published artists matching the filter.
@@ -314,24 +326,32 @@ func filingLetterExpression(letter string) dbx.Expression {
 // generation performs the catalogue-wide expansion once; bounded artist pages
 // then resolve availability by intersecting their records with this set.
 func (r *ArtistIndexRepository) publishedArtworkAuthorIDs() (artistAvailabilitySet, error) {
-	return utils.GetOrLoadCachedValue(r.app, artistAvailabilityCacheKey, 0, func() (artistAvailabilitySet, error) {
-		rows := []struct {
-			AuthorID string `db:"author_id"`
-		}{}
-		if err := r.app.DB().NewQuery(`
-			SELECT DISTINCT je.value AS author_id
-			FROM Artworks
-			CROSS JOIN json_each(Artworks.author) je
-			WHERE Artworks.published IS true AND je.value != ''
-		`).All(&rows); err != nil {
-			return nil, err
+	load := r.loadArtistAvailability
+	if load == nil {
+		load = func() (artistAvailabilitySet, error) {
+			return loadPublishedArtworkAuthorIDs(r.app)
 		}
+	}
+	return utils.GetOrLoadCachedValue(r.app, artistAvailabilityCacheKey, 0, load)
+}
 
-		available := make(artistAvailabilitySet, len(rows))
-		for _, row := range rows {
-			available[row.AuthorID] = struct{}{}
-		}
+func loadPublishedArtworkAuthorIDs(app core.App) (artistAvailabilitySet, error) {
+	rows := []struct {
+		AuthorID string `db:"author_id"`
+	}{}
+	if err := app.DB().NewQuery(`
+		SELECT DISTINCT je.value AS author_id
+		FROM Artworks
+		CROSS JOIN json_each(Artworks.author) je
+		WHERE Artworks.published IS true AND je.value != ''
+	`).All(&rows); err != nil {
+		return nil, err
+	}
 
-		return available, nil
-	})
+	available := make(artistAvailabilitySet, len(rows))
+	for _, row := range rows {
+		available[row.AuthorID] = struct{}{}
+	}
+
+	return available, nil
 }

--- a/internal/repositories/artist_index.go
+++ b/internal/repositories/artist_index.go
@@ -126,8 +126,8 @@ func (r *ArtistIndexRepository) CountArtists(filter ArtistIndexFilter) (int, err
 }
 
 // ListArtists returns the published artists matching the filter in deterministic
-// order. Availability is resolved once per page with a single bound aggregate
-// query and is skipped entirely for an empty page.
+// order. Availability is intersected from the application-scoped published-work
+// projection and is skipped entirely for an empty page.
 func (r *ArtistIndexRepository) ListArtists(filter ArtistIndexFilter) ([]IndexedArtist, error) {
 	present, err := artistsIdentityFieldsPresent(r.app)
 	if err != nil {

--- a/internal/repositories/artist_index_test.go
+++ b/internal/repositories/artist_index_test.go
@@ -271,6 +271,49 @@ func TestArtistIndexRepositoryMatchesUnicodeCaseVariants(t *testing.T) {
 	}
 }
 
+func TestArtistIndexRepositoryPublishedArtworkAuthorIDsProjection(t *testing.T) {
+	t.Run("empty data", func(t *testing.T) {
+		app := newArtistIndexTestApp(t)
+
+		available, err := NewArtistIndexRepository(app).publishedArtworkAuthorIDs()
+		if err != nil {
+			t.Fatalf("load empty availability: %v", err)
+		}
+		if len(available) != 0 {
+			t.Fatalf("empty availability = %v, want empty", available)
+		}
+	})
+
+	t.Run("published relations", func(t *testing.T) {
+		app := newArtistIndexTestApp(t)
+		saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "directart100000", name: "Direct Artist", published: true})
+		saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "coauthart000001", name: "Co-author Artist", published: true})
+		saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "hiddenart000001", name: "Hidden Work Artist", published: true})
+
+		// Repeated published relations collapse to one set member.
+		saveArtistIndexArtwork(t, app, "workdirect10000", []string{"directart100000"}, true)
+		saveArtistIndexArtwork(t, app, "workshared10000", []string{"directart100000", "coauthart000001"}, true)
+		// Unpublished works do not confer availability.
+		saveArtistIndexArtwork(t, app, "workhidden10000", []string{"hiddenart000001"}, false)
+
+		available, err := NewArtistIndexRepository(app).publishedArtworkAuthorIDs()
+		if err != nil {
+			t.Fatalf("load availability: %v", err)
+		}
+		if len(available) != 2 {
+			t.Fatalf("availability = %v, want direct artist and co-author only", available)
+		}
+		for _, id := range []string{"directart100000", "coauthart000001"} {
+			if _, ok := available[id]; !ok {
+				t.Errorf("availability missing %q", id)
+			}
+		}
+		if _, ok := available["hiddenart000001"]; ok {
+			t.Error("unpublished artwork conferred availability")
+		}
+	})
+}
+
 func TestArtistIndexRepositoryDerivesAvailability(t *testing.T) {
 	app := newArtistIndexTestApp(t)
 	saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "artavail1000000", name: "Available Artist", published: true})

--- a/internal/repositories/artist_index_test.go
+++ b/internal/repositories/artist_index_test.go
@@ -371,6 +371,38 @@ func TestArtistIndexAvailabilityInvalidationDuringLoadDoesNotRestoreStaleProject
 	}
 }
 
+func TestArtistIndexRepositoryReusesAvailabilityAcrossPagesAndInstances(t *testing.T) {
+	app := newArtistIndexTestApp(t)
+	saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "pageartist00001", name: "Alpha Artist", published: true})
+	saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "pageartist00002", name: "Beta Artist", published: true})
+	saveArtistIndexArtwork(t, app, "pageartwork0001", []string{"pageartist00001", "pageartist00002"}, true)
+
+	queryCount, err := countRecordQueries(app, func() error {
+		first, err := NewArtistIndexRepository(app).ListArtists(ArtistIndexFilter{Limit: 1})
+		if err != nil {
+			return err
+		}
+		if len(first) != 1 || !first[0].Available {
+			t.Fatalf("first page = %#v, want one available artist", first)
+		}
+
+		second, err := NewArtistIndexRepository(app).ListArtists(ArtistIndexFilter{Limit: 1, Offset: 1})
+		if err != nil {
+			return err
+		}
+		if len(second) != 1 || !second[0].Available {
+			t.Fatalf("second page = %#v, want one available artist", second)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("list repeated artist pages: %v", err)
+	}
+	if queryCount != 3 {
+		t.Fatalf("query count = %d, want two bounded artist reads plus one shared availability read", queryCount)
+	}
+}
+
 func TestArtistIndexRepositoryDerivesAvailability(t *testing.T) {
 	app := newArtistIndexTestApp(t)
 	saveArtistIndexArtist(t, app, artistIndexArtistSeed{id: "artavail1000000", name: "Available Artist", published: true})

--- a/internal/repositories/artist_index_test.go
+++ b/internal/repositories/artist_index_test.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/core"
@@ -312,6 +313,62 @@ func TestArtistIndexRepositoryPublishedArtworkAuthorIDsProjection(t *testing.T) 
 			t.Error("unpublished artwork conferred availability")
 		}
 	})
+}
+
+func TestArtistIndexAvailabilityInvalidationDuringLoadDoesNotRestoreStaleProjection(t *testing.T) {
+	app := newArtistIndexTestApp(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	loads := 0
+	repo := &ArtistIndexRepository{
+		app: app,
+		loadArtistAvailability: func() (artistAvailabilitySet, error) {
+			loads++
+			if loads == 1 {
+				close(started)
+				<-release
+				return artistAvailabilitySet{"staleartist0001": {}}, nil
+			}
+			return artistAvailabilitySet{"freshartist0001": {}}, nil
+		},
+	}
+
+	first := make(chan artistAvailabilitySet, 1)
+	go func() {
+		available, _ := repo.publishedArtworkAuthorIDs()
+		first <- available
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("availability load did not start")
+	}
+	InvalidateArtistAvailability(app)
+	close(release)
+
+	select {
+	case available := <-first:
+		if _, ok := available["staleartist0001"]; !ok {
+			t.Fatalf("in-flight caller received %v, want its completed stale generation", available)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("invalidated availability load did not complete")
+	}
+
+	available, err := repo.publishedArtworkAuthorIDs()
+	if err != nil {
+		t.Fatalf("load fresh availability: %v", err)
+	}
+	if loads != 2 {
+		t.Fatalf("availability loads = %d, want 2 generations", loads)
+	}
+	if _, ok := available["freshartist0001"]; !ok {
+		t.Fatalf("fresh availability = %v, want fresh artist", available)
+	}
+	if _, ok := available["staleartist0001"]; ok {
+		t.Fatalf("stale availability was restored after invalidation: %v", available)
+	}
 }
 
 func TestArtistIndexRepositoryDerivesAvailability(t *testing.T) {

--- a/internal/repositories/artwork_catalogue_revision.go
+++ b/internal/repositories/artwork_catalogue_revision.go
@@ -1,0 +1,26 @@
+package repositories
+
+import (
+	"sync/atomic"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const artworkCatalogueRevisionKey = "artworks:catalogue:revision"
+
+func artworkCatalogueRevisionCounter(app core.App) *atomic.Uint64 {
+	return app.Store().GetOrSet(artworkCatalogueRevisionKey, func() any {
+		return &atomic.Uint64{}
+	}).(*atomic.Uint64)
+}
+
+// ArtworkCatalogueRevision returns the process-local artwork mutation revision.
+func ArtworkCatalogueRevision(app core.App) uint64 {
+	return artworkCatalogueRevisionCounter(app).Load()
+}
+
+// AdvanceArtworkCatalogueRevision marks page selections made before an artwork
+// mutation as candidates for revalidation.
+func AdvanceArtworkCatalogueRevision(app core.App) {
+	artworkCatalogueRevisionCounter(app).Add(1)
+}

--- a/internal/repositories/collection_holdings.go
+++ b/internal/repositories/collection_holdings.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	"github.com/blackfyre/wga/internal/utils"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+const collectionHoldingsCacheKey = "artworks:search:collection-holdings"
+
+// CollectionHolding is one location and its eligible published-work count.
+// Zero-count locations are retained so selected values can be resolved from the
+// complete projection without a request-specific lookup.
+type CollectionHolding struct {
+	Value string `db:"value"`
+	Label string `db:"label"`
+	Count int    `db:"holding_count"`
+}
+
+// LoadCollectionHoldings returns the application-scoped counted location
+// projection. Counts match the artwork-search eligibility predicate.
+func LoadCollectionHoldings(app core.App) ([]CollectionHolding, error) {
+	return collectionHoldingsWithLoader(app, func() ([]CollectionHolding, error) {
+		rows := []CollectionHolding{}
+		err := app.DB().NewQuery(`
+			SELECT
+				locations.id AS value,
+				locations.name AS label,
+				COUNT(DISTINCT artworks.id) AS holding_count
+			FROM locations
+			LEFT JOIN artworks
+				ON artworks.current_location_id = locations.id
+				AND artworks.published = TRUE
+				AND json_array_length(artworks.author) > 0
+				AND EXISTS (
+					SELECT 1 FROM artists
+					WHERE artists.id = json_extract(artworks.author, '$[0]')
+				)
+			GROUP BY locations.id, locations.name`).All(&rows)
+		return rows, err
+	})
+}
+
+func collectionHoldingsWithLoader(app core.App, load func() ([]CollectionHolding, error)) ([]CollectionHolding, error) {
+	return utils.GetOrLoadCachedValue(app, collectionHoldingsCacheKey, 0, load)
+}
+
+// InvalidateCollectionHoldings advances the projection generation so the next
+// lookup observes current persisted locations, artworks, and first authors.
+func InvalidateCollectionHoldings(app core.App) {
+	utils.DeleteCachedValue(app, collectionHoldingsCacheKey)
+}

--- a/internal/repositories/collection_holdings_test.go
+++ b/internal/repositories/collection_holdings_test.go
@@ -1,0 +1,60 @@
+package repositories
+
+import (
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tests"
+)
+
+func TestCollectionHoldingsInvalidationDuringLoadDoesNotRestoreStaleProjection(t *testing.T) {
+	app, err := tests.NewTestApp()
+	if err != nil {
+		t.Fatalf("create test app: %v", err)
+	}
+	t.Cleanup(app.Cleanup)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	staleResult := make(chan []CollectionHolding, 1)
+	go func() {
+		value, loadErr := collectionHoldingsWithLoader(app, func() ([]CollectionHolding, error) {
+			close(started)
+			<-release
+			return []CollectionHolding{{Value: "stale", Label: "Stale", Count: 1}}, nil
+		})
+		if loadErr != nil {
+			staleResult <- nil
+			return
+		}
+		staleResult <- value
+	}()
+
+	<-started
+	InvalidateCollectionHoldings(app)
+	fresh := []CollectionHolding{{Value: "fresh", Label: "Fresh", Count: 2}}
+	loaded, err := collectionHoldingsWithLoader(app, func() ([]CollectionHolding, error) {
+		return fresh, nil
+	})
+	if err != nil {
+		t.Fatalf("load fresh projection: %v", err)
+	}
+	if len(loaded) != 1 || loaded[0] != fresh[0] {
+		t.Fatalf("fresh projection = %#v", loaded)
+	}
+
+	close(release)
+	if stale := <-staleResult; len(stale) != 1 || stale[0].Value != "stale" {
+		t.Fatalf("original caller result = %#v, want its completed stale load", stale)
+	}
+
+	cached, err := collectionHoldingsWithLoader(app, func() ([]CollectionHolding, error) {
+		t.Fatal("obsolete load replaced the fresh cached projection")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("read cached projection: %v", err)
+	}
+	if len(cached) != 1 || cached[0] != fresh[0] {
+		t.Fatalf("cached projection = %#v, want fresh projection", cached)
+	}
+}

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -15,6 +15,14 @@ const (
 type cachedValueState struct {
 	mu         sync.Mutex
 	generation uint64
+	loading    *cachedValueLoad
+}
+
+type cachedValueLoad struct {
+	generation uint64
+	done       chan struct{}
+	value      any
+	err        error
 }
 
 func cacheExpiryKey(key string) string {
@@ -75,20 +83,42 @@ func GetOrLoadCachedValue[T any](app core.App, key string, ttl time.Duration, lo
 		return cached, nil
 	}
 	generation := state.generation
+	if loading := state.loading; loading != nil && loading.generation == generation {
+		state.mu.Unlock()
+		<-loading.done
+		if loading.err != nil {
+			return zero, loading.err
+		}
+		if value, ok := loading.value.(T); ok {
+			return value, nil
+		}
+		return GetOrLoadCachedValue(app, key, ttl, load)
+	}
+
+	loading := &cachedValueLoad{
+		generation: generation,
+		done:       make(chan struct{}),
+	}
+	state.loading = loading
 	state.mu.Unlock()
 
 	value, err := load()
+
+	state.mu.Lock()
+	loading.value = value
+	loading.err = err
+	if err == nil && generation == state.generation {
+		SetCachedValue(app, key, value, ttl)
+	}
+	if state.loading == loading {
+		state.loading = nil
+	}
+	close(loading.done)
+	state.mu.Unlock()
+
 	if err != nil {
 		return zero, err
 	}
-
-	state.mu.Lock()
-	defer state.mu.Unlock()
-
-	if generation == state.generation {
-		SetCachedValue(app, key, value, ttl)
-	}
-
 	return value, nil
 }
 

--- a/internal/utils/cache.go
+++ b/internal/utils/cache.go
@@ -1,11 +1,14 @@
 package utils
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
 )
+
+var errCachedValueLoaderPanicked = errors.New("cached value loader panicked")
 
 const (
 	cacheExpirySuffix = ":meta:expires_unix_nano"
@@ -102,19 +105,31 @@ func GetOrLoadCachedValue[T any](app core.App, key string, ttl time.Duration, lo
 	state.loading = loading
 	state.mu.Unlock()
 
-	value, err := load()
+	var value T
+	var err error
+	defer func() {
+		panicValue := recover()
 
-	state.mu.Lock()
-	loading.value = value
-	loading.err = err
-	if err == nil && generation == state.generation {
-		SetCachedValue(app, key, value, ttl)
-	}
-	if state.loading == loading {
-		state.loading = nil
-	}
-	close(loading.done)
-	state.mu.Unlock()
+		state.mu.Lock()
+		loading.value = value
+		loading.err = err
+		if panicValue != nil {
+			loading.err = errCachedValueLoaderPanicked
+		} else if err == nil && generation == state.generation {
+			SetCachedValue(app, key, value, ttl)
+		}
+		if state.loading == loading {
+			state.loading = nil
+		}
+		close(loading.done)
+		state.mu.Unlock()
+
+		if panicValue != nil {
+			panic(panicValue)
+		}
+	}()
+
+	value, err = load()
 
 	if err != nil {
 		return zero, err

--- a/internal/utils/cache_test.go
+++ b/internal/utils/cache_test.go
@@ -1,7 +1,10 @@
 package utils
 
 import (
+	"errors"
+	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/pocketbase/pocketbase"
@@ -83,39 +86,188 @@ func TestGetOrLoadCachedValueCachesLoadedValue(t *testing.T) {
 }
 
 func TestGetOrLoadCachedValueDoesNotRestoreInvalidatedValue(t *testing.T) {
-	app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
-	key := "cache:test:invalidation-race"
-	started := make(chan struct{})
-	release := make(chan struct{})
-	type result struct {
-		value string
-		err   error
-	}
-	results := make(chan result, 1)
+	synctest.Test(t, func(t *testing.T) {
+		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+		key := "cache:test:invalidation-race"
+		staleStarted := make(chan struct{})
+		freshStarted := make(chan struct{})
+		releaseStale := make(chan struct{})
+		releaseFresh := make(chan struct{})
+		type result struct {
+			value string
+			err   error
+		}
+		staleResult := make(chan result, 1)
+		freshResult := make(chan result, 1)
 
-	go func() {
-		value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
-			close(started)
-			<-release
-			return "stale", nil
+		go func() {
+			value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+				close(staleStarted)
+				<-releaseStale
+				return "stale", nil
+			})
+			staleResult <- result{value: value, err: err}
+		}()
+
+		<-staleStarted
+		DeleteCachedValue(app, key)
+		go func() {
+			value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+				close(freshStarted)
+				<-releaseFresh
+				return "fresh", nil
+			})
+			freshResult <- result{value: value, err: err}
+		}()
+
+		<-freshStarted
+		close(releaseFresh)
+		fresh := <-freshResult
+		if fresh.err != nil || fresh.value != "fresh" {
+			t.Fatalf("fresh load = (%q, %v), want (fresh, nil)", fresh.value, fresh.err)
+		}
+
+		close(releaseStale)
+		stale := <-staleResult
+		if stale.err != nil || stale.value != "stale" {
+			t.Fatalf("stale in-flight load = (%q, %v), want (stale, nil)", stale.value, stale.err)
+		}
+
+		cached, ok := GetCachedValue[string](app, key)
+		if !ok || cached != "fresh" {
+			t.Fatalf("cached value = (%q, %t), want (fresh, true)", cached, ok)
+		}
+	})
+}
+
+func TestGetOrLoadCachedValueCoalescesConcurrentMisses(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+		const callers = 12
+		started := make(chan struct{})
+		release := make(chan struct{})
+		results := make(chan string, callers)
+		errors := make(chan error, callers)
+		var loads atomic.Int32
+
+		for range callers {
+			go func() {
+				value, err := GetOrLoadCachedValue(app, "cache:test:coalesced", time.Hour, func() (string, error) {
+					if loads.Add(1) == 1 {
+						close(started)
+					}
+					<-release
+					return "shared", nil
+				})
+				results <- value
+				errors <- err
+			}()
+		}
+
+		<-started
+		synctest.Wait()
+		if got := loads.Load(); got != 1 {
+			t.Fatalf("loader calls before release = %d, want 1", got)
+		}
+		close(release)
+
+		for range callers {
+			if err := <-errors; err != nil {
+				t.Fatalf("coalesced load: %v", err)
+			}
+			if value := <-results; value != "shared" {
+				t.Fatalf("coalesced value = %q, want shared", value)
+			}
+		}
+		if got := loads.Load(); got != 1 {
+			t.Fatalf("loader calls = %d, want 1", got)
+		}
+	})
+}
+
+func TestGetOrLoadCachedValueSharesButDoesNotCacheFailure(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+		const callers = 8
+		wantErr := errors.New("load failed")
+		started := make(chan struct{})
+		release := make(chan struct{})
+		results := make(chan error, callers)
+		var loads atomic.Int32
+
+		for range callers {
+			go func() {
+				_, err := GetOrLoadCachedValue(app, "cache:test:error", time.Hour, func() (string, error) {
+					if loads.Add(1) == 1 {
+						close(started)
+					}
+					<-release
+					return "", wantErr
+				})
+				results <- err
+			}()
+		}
+
+		<-started
+		synctest.Wait()
+		if got := loads.Load(); got != 1 {
+			t.Fatalf("loader calls before release = %d, want 1", got)
+		}
+		close(release)
+		for range callers {
+			if err := <-results; !errors.Is(err, wantErr) {
+				t.Fatalf("coalesced error = %v, want %v", err, wantErr)
+			}
+		}
+
+		value, err := GetOrLoadCachedValue(app, "cache:test:error", time.Hour, func() (string, error) {
+			loads.Add(1)
+			return "recovered", nil
 		})
-		results <- result{value: value, err: err}
-	}()
+		if err != nil || value != "recovered" {
+			t.Fatalf("retry = (%q, %v), want (recovered, nil)", value, err)
+		}
+		if got := loads.Load(); got != 2 {
+			t.Fatalf("loader calls after retry = %d, want 2", got)
+		}
+	})
+}
 
-	<-started
-	DeleteCachedValue(app, key)
-	close(release)
+func TestGetOrLoadCachedValueLoadsUnrelatedKeysIndependently(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+		startedA := make(chan struct{})
+		startedB := make(chan struct{})
+		release := make(chan struct{})
+		results := make(chan string, 2)
 
-	loaded := <-results
-	if loaded.err != nil {
-		t.Fatalf("load cached value: %v", loaded.err)
-	}
+		for key, started := range map[string]chan struct{}{
+			"cache:test:key-a": startedA,
+			"cache:test:key-b": startedB,
+		} {
+			go func() {
+				value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+					close(started)
+					<-release
+					return key, nil
+				})
+				if err != nil {
+					t.Errorf("load %s: %v", key, err)
+				}
+				results <- value
+			}()
+		}
 
-	if loaded.value != "stale" {
-		t.Fatalf("expected in-flight result 'stale', got %q", loaded.value)
-	}
+		<-startedA
+		<-startedB
+		close(release)
 
-	if _, ok := GetCachedValue[string](app, key); ok {
-		t.Fatalf("expected invalidated value to remain absent")
-	}
+		seen := map[string]bool{}
+		for range 2 {
+			seen[<-results] = true
+		}
+		if !seen["cache:test:key-a"] || !seen["cache:test:key-b"] {
+			t.Fatalf("loaded keys = %v, want both unrelated keys", seen)
+		}
+	})
 }

--- a/internal/utils/cache_test.go
+++ b/internal/utils/cache_test.go
@@ -233,6 +233,61 @@ func TestGetOrLoadCachedValueSharesButDoesNotCacheFailure(t *testing.T) {
 	})
 }
 
+func TestGetOrLoadCachedValueReleasesWaitersWhenLoaderPanics(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})
+		const key = "cache:test:panic"
+		const panicValue = "loader panic"
+		started := make(chan struct{})
+		release := make(chan struct{})
+		panics := make(chan any, 1)
+		waiterErrors := make(chan error, 1)
+		var loads atomic.Int32
+
+		go func() {
+			defer func() { panics <- recover() }()
+			_, _ = GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+				loads.Add(1)
+				close(started)
+				<-release
+				panic(panicValue)
+			})
+		}()
+
+		<-started
+		go func() {
+			_, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+				loads.Add(1)
+				return "unexpected", nil
+			})
+			waiterErrors <- err
+		}()
+		synctest.Wait()
+		if got := loads.Load(); got != 1 {
+			t.Fatalf("loader calls before panic = %d, want 1", got)
+		}
+
+		close(release)
+		if got := <-panics; got != panicValue {
+			t.Fatalf("recovered panic = %#v, want %q", got, panicValue)
+		}
+		if err := <-waiterErrors; !errors.Is(err, errCachedValueLoaderPanicked) {
+			t.Fatalf("waiter error = %v, want %v", err, errCachedValueLoaderPanicked)
+		}
+
+		value, err := GetOrLoadCachedValue(app, key, time.Hour, func() (string, error) {
+			loads.Add(1)
+			return "recovered", nil
+		})
+		if err != nil || value != "recovered" {
+			t.Fatalf("retry = (%q, %v), want (recovered, nil)", value, err)
+		}
+		if got := loads.Load(); got != 2 {
+			t.Fatalf("loader calls after retry = %d, want 2", got)
+		}
+	})
+}
+
 func TestGetOrLoadCachedValueLoadsUnrelatedKeysIndependently(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		app := pocketbase.NewWithConfig(pocketbase.Config{DefaultDataDir: "./wga_data"})

--- a/openspec/changes/improve-public-catalogue-performance/.openspec.yaml
+++ b/openspec/changes/improve-public-catalogue-performance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/improve-public-catalogue-performance/design.md
+++ b/openspec/changes/improve-public-catalogue-performance/design.md
@@ -1,0 +1,84 @@
+## Context
+
+See `proposal.md` for motivation. WGA is a single PocketBase process backed by SQLite. Profiling against 5,829 artists and 52,866 artworks showed SQLite consuming 95–97% of CPU on concurrent `/artworks`, `/artworks/results`, and `/dual-mode` requests, while forced-GC profiles retained almost no route-owned heap.
+
+Three avoidable paths dominate. The results-only artwork endpoint builds the complete filter/facet view before rendering only its results. Artist availability expands every published artwork's JSON author relation for each displayed artist page. Collection options aggregate the full published catalogue and concurrent cold cache misses can execute the same loader repeatedly because the current cache helper does not coalesce in-flight loads. The default artist order also lacks an index over `filing_name`.
+
+The authoritative catalogue specification requires exact artist matching to include co-authored works and requires unchanged filtering, URL, paging, no-JavaScript, and Dual Mode behaviour. An optimisation that treats only the first author as authoritative is therefore invalid even if it produces a faster query.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Remove data work that is not represented in the requested artwork-search fragment.
+- Make repeated catalogue-wide reference derivations bounded, shared, and safely invalidated.
+- Preserve co-author-correct artist availability and current collection-holding semantics.
+- Add only indexes whose supported query plans and representative measurements demonstrate value.
+- Compare before-and-after CPU, allocations, query plans, and concurrent cold-load behaviour.
+
+**Non-Goals:**
+
+- Caching personalised full-page or HTMX HTML.
+- Adding Valkey, Redis, another service, or another deployment replica.
+- Optimising startup sitemap or agent-publication generation.
+- Changing public filters, routes, URL state, page size, result order, or admission thresholds.
+- Tuning Go or SQLite memory settings before request work is reduced and re-profiled.
+
+## Decisions
+
+### Split results projection from full search-view assembly
+
+The artwork search capability will expose a results workflow that parses the same canonical filter state and loads only the result count, requested records, result projection, and pagination data. Full-page and complete search-block responses will compose that results workflow with filter-option and collection projections. The handler will select the response contract from the route and validated HTMX target, invoke the matching workflow, and render its fragment.
+
+This preserves one source of truth for result semantics while ensuring `/artworks/results` cannot accidentally pay for facets it does not return. Keeping one monolithic builder with skip flags was rejected because it makes invalid field combinations representable and obscures which reads each fragment requires.
+
+### Cache complete bounded projections, not arbitrary request responses
+
+Artist availability will be represented by the complete set of artist IDs occurring anywhere in published artwork author relations. It will be loaded once per cache generation, reused by artist and Dual Mode page projections, and intersected with each bounded candidate page in memory. This preserves co-authored works while changing a catalogue-wide expansion from per request to per generation.
+
+Collection holdings will likewise be cached as the complete counted location projection. Query-specific name filtering, deterministic ordering, the forty-option limit, selected-value retention, and omitted-holdings accounting will run against that bounded projection in memory. Arbitrary query strings and rendered responses will not become cache keys.
+
+An indexed first-author expression was rejected for artist availability because it violates co-author semantics. A normalised artwork-author table was deferred because the current mostly read-only catalogue does not yet justify a new persisted relation, import contract, and reconciliation workflow; it remains an alternative if bounded projection loading later proves too expensive.
+
+### Coalesce cold loads in the shared cache primitive
+
+The application cache helper will guarantee one in-flight loader per application and cache key. Concurrent callers will wait for that load and receive the same value or error. Invalidation will advance the existing generation before removing a value; a load begun under an obsolete generation must not republish stale data. The helper will not retain failed values, and unrelated keys will remain independent.
+
+Changing only the venue caller was rejected because artist availability needs the same guarantee and the existing generic helper already owns cache-generation concurrency. The change must include deterministic concurrency and invalidation-race tests before callers adopt it.
+
+### Invalidate projections from owning record lifecycle hooks
+
+Artwork changes affecting publication, authors, or current location invalidate both reusable projections. Location changes affecting identity or display name invalidate collection holdings. Artist deletion or restoration invalidates collection holdings because the existing collection aggregate counts works only when its first author exists. Invalidation may conservatively occur for all saves in these owning collections when field-level change detection would be less reliable; correctness takes priority over avoiding a cheap cache eviction.
+
+Hooks will only invalidate application cache state. Projection queries and transformation rules remain in the owning repository/workflow packages rather than lifecycle adapters.
+
+### Add query indexes as reversible PocketBase migrations
+
+A timestamped migration will add indexes matching supported published-artist orders, beginning with `(published, filing_name, id)` and adding the birth-year order only if `EXPLAIN QUERY PLAN` and representative benchmarks show it removes a scan or temporary sort. The migration will use the repository's PocketBase collection-index conventions and provide a down path that removes only its own indexes.
+
+Indexes for arbitrary substring filters or `json_each` output will not be added: ordinary SQLite expression indexes cannot index the multiple rows emitted by a JSON table-valued expansion. Each proposed index must be justified by an exercised public query, not merely by a column appearing in a predicate.
+
+### Treat list/count consolidation as an evidence-gated experiment
+
+Artwork record listing and total counting currently repeat substantially the same filter predicates. A combined window-count query may reduce duplicate JSON and predicate work, but SQLite must still count all matches and may choose a worse sort plan. Implementation will compare the existing and combined forms on unfiltered, text, exact-artist, venue, and date-filter cases. The combined form will be retained only if results are identical and representative CPU/allocation evidence improves without a material regression in any supported case.
+
+### Verify structure and measured effect separately
+
+Deterministic tests will prove fragment read boundaries, co-author semantics, cache single-flight behaviour, invalidation, migration rollback, and unchanged HTTP/HTMX output. Query-plan inspection and production-shaped local profiles will then establish whether each structurally correct change improves the observed workload. Wall-clock thresholds will not be CI acceptance criteria because shared-runner timing is unstable; before-and-after commands, dataset cardinality, request concurrency, throughput, CPU samples, allocations, and retained heap will be reported together.
+
+## Risks / Trade-offs
+
+- [A reusable projection can become stale after a mutation] -> Invalidate from the owning record hooks and test save/delete plus in-flight invalidation races.
+- [Coalescing loads can turn a slow loader into waiting callers] -> Keep projections bounded, preserve request admission ahead of handlers, share failures without caching them, and measure cold-load latency.
+- [Caching complete projections raises retained heap] -> Store compact DTOs/sets rather than PocketBase records, measure forced-GC retained heap, and reject the approach if its bounded footprint is material.
+- [New indexes increase database size and write cost] -> Add only plan-proven indexes, measure database growth, and provide a migration down path.
+- [Results/full-view separation can drift semantically] -> Make the full view compose the same results workflow and retain shared filter parsing and canonical URL tests.
+- [Synthetic benchmarks can hide production data distributions] -> Use deterministic tests for correctness and repeat local profiles against the production-shaped copied dataset for performance conclusions.
+
+## Migration Plan
+
+1. Establish repeatable baseline profiles and query plans for the agreed route/filter matrix.
+2. Deploy workflow and bounded-cache changes without altering public contracts; caches begin empty and populate on demand.
+3. Apply proven artist indexes through the normal PocketBase migration lifecycle.
+4. Re-run the same profile matrix and compare CPU, allocation, throughput, and retained heap evidence.
+5. Roll back application changes normally if semantics or resource use regress; roll back the index migration by removing only the newly named indexes. No persisted catalogue data is transformed.

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -1,0 +1,44 @@
+## Artist query-index evidence
+
+### Task 5.1 — candidate selection
+
+Evidence was captured with SQLite 3.53.3 from a consistent backup of the local
+production-shaped PocketBase database: 5,829 eligible published artists and
+52,866 artworks. The exercised list shape selected `Artists.*`, applied the
+canonical published/complete-identity predicate, and used `LIMIT 60 OFFSET 0`.
+Only the `ORDER BY` changed:
+
+- name ascending: `filing_name ASC, id ASC`
+- name descending: `filing_name DESC, id ASC`
+- birth: `(year_of_birth = 0) ASC, year_of_birth ASC, filing_name ASC, id ASC`
+
+Before the candidates, all three shapes searched
+`pbx_artist_published_name (published=?)` and reported
+`USE TEMP B-TREE FOR ORDER BY`.
+
+The selected candidates and resulting plans are:
+
+| Index | Exercised result |
+| --- | --- |
+| `pbx_artist_published_filing` on `(published, filing_name, id)` | Name ascending searches this index with no temporary sort. Name descending uses it but retains `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` because the deterministic `id ASC` direction differs from a reverse scan. |
+| `pbx_artist_published_filing_desc` on `(published, filing_name DESC, id ASC)` | Name descending searches this index with no temporary sort. |
+| `pbx_artist_published_birth` on `(published, (year_of_birth = 0), year_of_birth, filing_name, id)` | Birth order searches this index with no temporary sort. |
+
+A plain birth candidate on
+`(published, year_of_birth, filing_name, id)` was rejected: the unknown-year
+ordering expression still produced `USE TEMP B-TREE FOR ORDER BY`.
+
+Database-size comparison used a compact backup (`VACUUM`, 4,096-byte pages) so
+free pages could not hide index allocation:
+
+| State | Pages | Bytes | Delta |
+| --- | ---: | ---: | ---: |
+| Baseline | 45,255 | 185,364,480 | — |
+| Ascending name added | 45,319 | 185,626,624 | +262,144 |
+| Descending name added | 45,383 | 185,888,768 | +262,144 |
+| Birth order added | 45,454 | 186,179,584 | +290,816 |
+| **All selected indexes** | **45,454** | **186,179,584** | **+815,104 bytes (0.44%)** |
+
+The un-compacted working snapshot had 146 free pages; the first candidate reused
+64 of them and therefore showed no physical file growth. The compact comparison
+above records the actual allocation rather than that incidental file-size result.

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -96,30 +96,30 @@ All measured requests returned HTTP 200 with zero load-generator errors.
 
 Unprofiled load results were:
 
-| Route | Baseline req/s | Final req/s | Throughput | Baseline mean | Final mean | Baseline p95 | Final p95 |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `/artworks` | 5.65 | 16.81 | +197.5% | 1,376.08 ms | 472.60 ms | 1,608.83 ms | 552.97 ms |
-| `/artworks/results` | 5.44 | 17.04 | +213.2% | 1,439.95 ms | 467.34 ms | 1,652.08 ms | 507.69 ms |
-| `/dual-mode` | 18.39 | 97.57 | +430.6% | 434.93 ms | 81.83 ms | 429.82 ms | 86.33 ms |
+| Route               | Baseline req/s | Final req/s | Throughput | Baseline mean | Final mean | Baseline p95 | Final p95 |
+| ------------------- | -------------: | ----------: | ---------: | ------------: | ---------: | -----------: | --------: |
+| `/artworks`         |           5.65 |       16.81 |    +197.5% |   1,376.08 ms |  472.60 ms |  1,608.83 ms | 552.97 ms |
+| `/artworks/results` |           5.44 |       17.04 |    +213.2% |   1,439.95 ms |  467.34 ms |  1,652.08 ms | 507.69 ms |
+| `/dual-mode`        |          18.39 |       97.57 |    +430.6% |     434.93 ms |   81.83 ms |    429.82 ms |  86.33 ms |
 
 Ten-second CPU profiles ran under the same eight-client load. Total samples can
 exceed wall time because requests execute across cores; dividing by completed
 requests gives the comparable CPU cost:
 
-| Route | Baseline samples / requests | Final samples / requests | CPU per request | Change |
-| --- | ---: | ---: | ---: | ---: |
-| `/artworks` | 39.59 s / 56 | 43.15 s / 176 | 706.96 → 245.17 ms | -65.3% |
-| `/artworks/results` | 39.26 s / 57 | 40.34 s / 168 | 688.77 → 240.12 ms | -65.1% |
-| `/dual-mode` | 50.09 s / 184 | 39.38 s / 977 | 272.23 → 40.31 ms | -85.2% |
+| Route               | Baseline samples / requests | Final samples / requests |    CPU per request | Change |
+| ------------------- | --------------------------: | -----------------------: | -----------------: | -----: |
+| `/artworks`         |                39.59 s / 56 |            43.15 s / 176 | 706.96 → 245.17 ms | -65.3% |
+| `/artworks/results` |                39.26 s / 57 |            40.34 s / 168 | 688.77 → 240.12 ms | -65.1% |
+| `/dual-mode`        |               50.09 s / 184 |            39.38 s / 977 |  272.23 → 40.31 ms | -85.2% |
 
 Exact `runtime.MemStats` deltas around separate ten-second runs supplied
 allocation counts rather than relying on sampled-profile totals:
 
-| Route | Baseline bytes/request | Final bytes/request | Baseline mallocs/request | Final mallocs/request |
-| --- | ---: | ---: | ---: | ---: |
-| `/artworks` | 1,451,462 | 1,415,550 (-2.5%) | 10,567 | 9,790 (-7.4%) |
-| `/artworks/results` | 777,719 | 725,909 (-6.7%) | 7,326 | 6,545 (-10.7%) |
-| `/dual-mode` | 2,140,278 | 2,100,161 (-1.9%) | 19,564 | 19,109 (-2.3%) |
+| Route               | Baseline bytes/request | Final bytes/request | Baseline mallocs/request | Final mallocs/request |
+| ------------------- | ---------------------: | ------------------: | -----------------------: | --------------------: |
+| `/artworks`         |              1,451,462 |   1,415,550 (-2.5%) |                   10,567 |         9,790 (-7.4%) |
+| `/artworks/results` |                777,719 |     725,909 (-6.7%) |                    7,326 |        6,545 (-10.7%) |
+| `/dual-mode`        |              2,140,278 |   2,100,161 (-1.9%) |                   19,564 |        19,109 (-2.3%) |
 
 An initial sampled allocation profile exposed avoidable allocation in the new
 in-memory collection ordering: repeatedly constructing folded labels and growing

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -18,11 +18,11 @@ Before the candidates, all three shapes searched
 
 The selected candidates and resulting plans are:
 
-| Index | Exercised result |
-| --- | --- |
-| `pbx_artist_published_filing` on `(published, filing_name, id)` | Name ascending searches this index with no temporary sort. Name descending uses it but retains `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` because the deterministic `id ASC` direction differs from a reverse scan. |
-| `pbx_artist_published_filing_desc` on `(published, filing_name DESC, id ASC)` | Name descending searches this index with no temporary sort. |
-| `pbx_artist_published_birth` on `(published, (year_of_birth = 0), year_of_birth, filing_name, id)` | Birth order searches this index with no temporary sort. |
+| Index                                                                                              | Exercised result                                                                                                                                                                                                     |
+| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pbx_artist_published_filing` on `(published, filing_name, id)`                                    | Name ascending searches this index with no temporary sort. Name descending uses it but retains `USE TEMP B-TREE FOR LAST TERM OF ORDER BY` because the deterministic `id ASC` direction differs from a reverse scan. |
+| `pbx_artist_published_filing_desc` on `(published, filing_name DESC, id ASC)`                      | Name descending searches this index with no temporary sort.                                                                                                                                                          |
+| `pbx_artist_published_birth` on `(published, (year_of_birth = 0), year_of_birth, filing_name, id)` | Birth order searches this index with no temporary sort.                                                                                                                                                              |
 
 A plain birth candidate on
 `(published, year_of_birth, filing_name, id)` was rejected: the unknown-year
@@ -31,12 +31,12 @@ ordering expression still produced `USE TEMP B-TREE FOR ORDER BY`.
 Database-size comparison used a compact backup (`VACUUM`, 4,096-byte pages) so
 free pages could not hide index allocation:
 
-| State | Pages | Bytes | Delta |
-| --- | ---: | ---: | ---: |
-| Baseline | 45,255 | 185,364,480 | — |
-| Ascending name added | 45,319 | 185,626,624 | +262,144 |
-| Descending name added | 45,383 | 185,888,768 | +262,144 |
-| Birth order added | 45,454 | 186,179,584 | +290,816 |
+| State                    |      Pages |           Bytes |                      Delta |
+| ------------------------ | ---------: | --------------: | -------------------------: |
+| Baseline                 |     45,255 |     185,364,480 |                          — |
+| Ascending name added     |     45,319 |     185,626,624 |                   +262,144 |
+| Descending name added    |     45,383 |     185,888,768 |                   +262,144 |
+| Birth order added        |     45,454 |     186,179,584 |                   +290,816 |
 | **All selected indexes** | **45,454** | **186,179,584** | **+815,104 bytes (0.44%)** |
 
 The un-compacted working snapshot had 146 free pages; the first candidate reused

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -42,3 +42,42 @@ free pages could not hide index allocation:
 The un-compacted working snapshot had 146 free pages; the first candidate reused
 64 of them and therefore showed no physical file growth. The compact comparison
 above records the actual allocation rather than that incidental file-size result.
+
+## Artwork list/count experiment
+
+### Task 6.1 — combined window count retained
+
+The candidate selects the ordered page IDs and `COUNT(*) OVER()` in one filtered
+query, then hydrates only those sixteen IDs. The previous implementation ran the
+complete filter predicates once for `COUNT(DISTINCT id)` and again for the page.
+An out-of-range page performs a fallback window read to recover the total and
+continues to clamp to the canonical final page.
+
+Deterministic equivalence passed for unfiltered, title/artist text, exact artist
+(including a synthetic co-authored match), venue, and date-range cases. The same
+five cases also matched total counts and ordered first-page IDs against the
+production-shaped 52,866-artwork database. Existing handler tests continued to
+pass the empty-result and out-of-range-page contracts.
+
+Benchmark command:
+
+```text
+WGA_PERF_DATA_DIR=<isolated-production-shaped-data> go test ./internal/handlers/artworks \
+  -run '^$' -bench '^BenchmarkArtworkListCountExperiment$' \
+  -benchmem -benchtime=10x -count=3
+```
+
+Median results on an AMD Ryzen 7 7800X3D were:
+
+| Case | Separate ns/op | Combined ns/op | Time | Bytes/op | Allocs/op |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Unfiltered | 206,875,197 | 153,419,884 | -25.8% | -9.3% | -4.3% |
+| Text (`Madonna`) | 339,097,616 | 185,719,145 | -45.2% | -15.5% | -9.0% |
+| Exact artist | 199,656,008 | 127,544,144 | -36.1% | -12.1% | -6.9% |
+| Venue | 14,114,029 | 10,837,172 | -23.2% | -8.4% | -4.8% |
+| Date range | 190,994,341 | 111,192,226 | -41.8% | -8.9% | -5.4% |
+
+A five-case, five-iteration process-level comparison reported 5.11 seconds of
+user CPU for the separate path and 3.49 seconds for the combined path (-31.7%);
+system CPU fell from 1.73 to 1.15 seconds. Every required case improved elapsed
+time, bytes, and allocations, so the combined path was retained.

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -69,13 +69,13 @@ WGA_PERF_DATA_DIR=<isolated-production-shaped-data> go test ./internal/handlers/
 
 Median results on an AMD Ryzen 7 7800X3D were:
 
-| Case | Separate ns/op | Combined ns/op | Time | Bytes/op | Allocs/op |
-| --- | ---: | ---: | ---: | ---: | ---: |
-| Unfiltered | 206,875,197 | 153,419,884 | -25.8% | -9.3% | -4.3% |
-| Text (`Madonna`) | 339,097,616 | 185,719,145 | -45.2% | -15.5% | -9.0% |
-| Exact artist | 199,656,008 | 127,544,144 | -36.1% | -12.1% | -6.9% |
-| Venue | 14,114,029 | 10,837,172 | -23.2% | -8.4% | -4.8% |
-| Date range | 190,994,341 | 111,192,226 | -41.8% | -8.9% | -5.4% |
+| Case             | Separate ns/op | Combined ns/op |   Time | Bytes/op | Allocs/op |
+| ---------------- | -------------: | -------------: | -----: | -------: | --------: |
+| Unfiltered       |    206,875,197 |    153,419,884 | -25.8% |    -9.3% |     -4.3% |
+| Text (`Madonna`) |    339,097,616 |    185,719,145 | -45.2% |   -15.5% |     -9.0% |
+| Exact artist     |    199,656,008 |    127,544,144 | -36.1% |   -12.1% |     -6.9% |
+| Venue            |     14,114,029 |     10,837,172 | -23.2% |    -8.4% |     -4.8% |
+| Date range       |    190,994,341 |    111,192,226 | -41.8% |    -8.9% |     -5.4% |
 
 A five-case, five-iteration process-level comparison reported 5.11 seconds of
 user CPU for the separate path and 3.49 seconds for the combined path (-31.7%);

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -156,3 +156,26 @@ artwork route, 95.98% for results-only, and 85.98% for Dual Mode—but it now se
 substantially more requests with lower CPU and allocation cost per request. No
 material throughput, latency, CPU, allocation, or retained-heap regression
 remained after investigation.
+
+### Task 7.2 — final regression and scope verification
+
+- Ran `gofmt` over every changed Go source and Prettier over every changed
+  JavaScript, TypeScript, and Markdown source.
+- `go vet ./...` passed.
+- `go test ./... -cover` passed: 1,964 tests across 61 packages.
+- `mise run app:build` regenerated frontend, email, Templ, licence, and Go build
+  outputs successfully.
+- The focused Chromium command passed all 35 artwork-search tests against an
+  isolated built application and synthetic fixture augmented with one eligible
+  collection holding:
+
+  ```text
+  playwright test artwork-search.spec.ts artwork-search-task71.spec.ts
+  ```
+
+- The final diff from baseline commit `83e6a35e` contains only the approved
+  artwork search, artist availability, collection holdings, shared cache,
+  invalidation hook, artist-index migration, tests, and OpenSpec evidence. It
+  contains no startup-generation, Cloudflare, external-cache,
+  admission-threshold, public-route registration, or unrelated runtime-tuning
+  changes.

--- a/openspec/changes/improve-public-catalogue-performance/evidence.md
+++ b/openspec/changes/improve-public-catalogue-performance/evidence.md
@@ -81,3 +81,78 @@ A five-case, five-iteration process-level comparison reported 5.11 seconds of
 user CPU for the separate path and 3.49 seconds for the combined path (-31.7%);
 system CPU fell from 1.73 to 1.15 seconds. Every required case improved elapsed
 time, bytes, and allocations, so the combined path was retained.
+
+## Final production-shaped profile matrix
+
+### Task 7.1 — before/after concurrent profiles
+
+The baseline was commit `83e6a35e`, immediately before this change. Both builds
+used Go 1.27.0 and independent copies of the same database: 5,829 artists,
+52,866 artworks, and 957 locations. Each route received one warm-up request,
+then eight concurrent clients for ten seconds with request protection disabled.
+`/artworks/results` carried `HX-Request: true` and targeted
+`artwork-search-results`; the other routes were ordinary public GET requests.
+All measured requests returned HTTP 200 with zero load-generator errors.
+
+Unprofiled load results were:
+
+| Route | Baseline req/s | Final req/s | Throughput | Baseline mean | Final mean | Baseline p95 | Final p95 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `/artworks` | 5.65 | 16.81 | +197.5% | 1,376.08 ms | 472.60 ms | 1,608.83 ms | 552.97 ms |
+| `/artworks/results` | 5.44 | 17.04 | +213.2% | 1,439.95 ms | 467.34 ms | 1,652.08 ms | 507.69 ms |
+| `/dual-mode` | 18.39 | 97.57 | +430.6% | 434.93 ms | 81.83 ms | 429.82 ms | 86.33 ms |
+
+Ten-second CPU profiles ran under the same eight-client load. Total samples can
+exceed wall time because requests execute across cores; dividing by completed
+requests gives the comparable CPU cost:
+
+| Route | Baseline samples / requests | Final samples / requests | CPU per request | Change |
+| --- | ---: | ---: | ---: | ---: |
+| `/artworks` | 39.59 s / 56 | 43.15 s / 176 | 706.96 → 245.17 ms | -65.3% |
+| `/artworks/results` | 39.26 s / 57 | 40.34 s / 168 | 688.77 → 240.12 ms | -65.1% |
+| `/dual-mode` | 50.09 s / 184 | 39.38 s / 977 | 272.23 → 40.31 ms | -85.2% |
+
+Exact `runtime.MemStats` deltas around separate ten-second runs supplied
+allocation counts rather than relying on sampled-profile totals:
+
+| Route | Baseline bytes/request | Final bytes/request | Baseline mallocs/request | Final mallocs/request |
+| --- | ---: | ---: | ---: | ---: |
+| `/artworks` | 1,451,462 | 1,415,550 (-2.5%) | 10,567 | 9,790 (-7.4%) |
+| `/artworks/results` | 777,719 | 725,909 (-6.7%) | 7,326 | 6,545 (-10.7%) |
+| `/dual-mode` | 2,140,278 | 2,100,161 (-1.9%) | 19,564 | 19,109 (-2.3%) |
+
+An initial sampled allocation profile exposed avoidable allocation in the new
+in-memory collection ordering: repeatedly constructing folded labels and growing
+the option slice accounted for about 122 KiB per full-page request. The final
+implementation preallocates from the bounded 957-location projection and uses an
+allocation-free ASCII `NOCASE` comparator. Focused race tests preserved the
+ordering and forty-option contracts, and the exact counters above show that the
+apparent full-page regression was removed.
+
+Forced-GC post-load `HeapAlloc` was 3.94 → 4.00 MiB for `/artworks`, 3.64 →
+3.96 MiB for `/artworks/results`, and 3.87 → 4.59 MiB for `/dual-mode`.
+The largest increase was 0.72 MiB and includes the deliberately bounded shared
+artist-availability set. Post-warm heap profile differences contained runtime,
+regular-expression, buffer, and SQLite sampling buckets, but no growing
+route-owned response cache or request-keyed catalogue projection.
+
+Dominant call-path comparison confirmed that the removed work no longer occurs
+per request:
+
+- Baseline `/artworks` spent 45.72% cumulative CPU in the catalogue-wide
+  `getVenueOptions` SQL query; the warmed final profile spent 0.18% in its
+  in-memory ordering, with no collection-holdings loader query sampled.
+- Baseline `/artworks/results` ran the full search-view builder for 96.84% of
+  sampled CPU, including facets. The final route ran only
+  `buildArtworkSearchResultsViewContext`; its remaining dominant work was the
+  combined ordered page/window-count query.
+- Baseline `/dual-mode` spent 70.79% cumulative CPU in the per-request
+  `publishedArtworkAuthorIDs` catalogue scan. The final profile contained no
+  sample for `loadPublishedArtworkAuthorIDs`; remaining application work was
+  headed by the bounded artist count (40.73%) and list (2.89%) queries.
+
+SQLite remains the dominant execution engine—96.08% cumulative CPU for the full
+artwork route, 95.98% for results-only, and 85.98% for Dual Mode—but it now serves
+substantially more requests with lower CPU and allocation cost per request. No
+material throughput, latency, CPU, allocation, or retained-heap regression
+remained after investigation.

--- a/openspec/changes/improve-public-catalogue-performance/proposal.md
+++ b/openspec/changes/improve-public-catalogue-performance/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Admitted catalogue and Dual Mode requests still perform avoidable full-dataset SQLite work, duplicate cold-cache loads, and substantial allocation churn. Production-sized profiling now identifies specific request paths where reducing cost per request can improve visitor latency and Railway headroom without broad response caching or additional infrastructure.
+
+## What Changes
+
+- Make artwork results-only requests load and project only the result data required by their returned fragment.
+- Replace repeated full-artwork author-availability scans with a bounded, co-author-correct reusable projection.
+- Make collection-holding options a bounded reusable projection and suppress duplicate work during concurrent cold loads.
+- Add database indexes that match supported public artist ordering and filtering paths where query-plan evidence demonstrates a benefit.
+- Evaluate consolidation of duplicate artwork list/count work and retain it only when representative profiling demonstrates an improvement.
+- Establish before-and-after query-plan, allocation, and concurrency evidence for each optimisation while preserving existing catalogue, paging, and Dual Mode behaviour.
+- Keep startup/background publication generation, Cloudflare configuration, external caches, and unrelated runtime tuning outside this change.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `catalogue-exploration`: Require results-only interactions and public catalogue reads to avoid unnecessary catalogue-wide work while preserving existing filtering, co-author, paging, and Dual Mode semantics.
+
+## Impact
+
+- Affects artwork search workflows and fragments, artist-index repositories, Dual Mode artist availability, application-scoped reference caching, cache invalidation hooks, and PocketBase schema indexes.
+- Adds focused query-plan, concurrency, allocation, repository, handler, and HTMX-contract verification.
+- Does not change public routes, URL parameters, rendered result semantics, deployment topology, or external dependencies.

--- a/openspec/changes/improve-public-catalogue-performance/specs/catalogue-exploration/spec.md
+++ b/openspec/changes/improve-public-catalogue-performance/specs/catalogue-exploration/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Public catalogue reads avoid unnecessary catalogue-wide work
+
+The system SHALL limit each public catalogue response to the data work required by that response, SHALL reuse bounded catalogue-wide projections where repeated derivation would otherwise scan the catalogue for each request, and SHALL preserve the existing catalogue results and navigation contract.
+
+#### Scenario: Results-only interaction
+- **WHEN** an enhanced artwork-search request asks for only the results fragment
+- **THEN** the system loads the matching result count and page without loading filter-option projections that are absent from the returned fragment
+
+#### Scenario: Artist availability is projected
+- **WHEN** an artist index or Dual Mode pane determines whether displayed artists have published works
+- **THEN** the system resolves availability from a reusable bounded projection without expanding every published artwork relation for that individual request
+
+#### Scenario: Co-authored work remains available
+- **WHEN** a displayed artist appears as any author of a published co-authored work
+- **THEN** the artist remains available under the optimised lookup
+
+#### Scenario: Concurrent cold projection requests
+- **WHEN** concurrent requests require the same application-scoped projection before it has been loaded
+- **THEN** the system performs one shared load and gives each successful requester an equivalent result
+
+#### Scenario: Catalogue projection becomes stale
+- **WHEN** a relevant artwork, artist, or collection record changes
+- **THEN** the next catalogue request derives affected reusable projections from current persisted data rather than serving the stale projection
+
+#### Scenario: Existing catalogue interaction is preserved
+- **WHEN** a visitor filters, sorts, pages, resets, changes result view, or hands a result to Dual Mode
+- **THEN** the resulting records, canonical URL state, fragment target, and progressive-enhancement behaviour remain consistent with the existing catalogue requirements

--- a/openspec/changes/improve-public-catalogue-performance/specs/catalogue-exploration/spec.md
+++ b/openspec/changes/improve-public-catalogue-performance/specs/catalogue-exploration/spec.md
@@ -5,25 +5,31 @@
 The system SHALL limit each public catalogue response to the data work required by that response, SHALL reuse bounded catalogue-wide projections where repeated derivation would otherwise scan the catalogue for each request, and SHALL preserve the existing catalogue results and navigation contract.
 
 #### Scenario: Results-only interaction
+
 - **WHEN** an enhanced artwork-search request asks for only the results fragment
 - **THEN** the system loads the matching result count and page without loading filter-option projections that are absent from the returned fragment
 
 #### Scenario: Artist availability is projected
+
 - **WHEN** an artist index or Dual Mode pane determines whether displayed artists have published works
 - **THEN** the system resolves availability from a reusable bounded projection without expanding every published artwork relation for that individual request
 
 #### Scenario: Co-authored work remains available
+
 - **WHEN** a displayed artist appears as any author of a published co-authored work
 - **THEN** the artist remains available under the optimised lookup
 
 #### Scenario: Concurrent cold projection requests
+
 - **WHEN** concurrent requests require the same application-scoped projection before it has been loaded
 - **THEN** the system performs one shared load and gives each successful requester an equivalent result
 
 #### Scenario: Catalogue projection becomes stale
+
 - **WHEN** a relevant artwork, artist, or collection record changes
 - **THEN** the next catalogue request derives affected reusable projections from current persisted data rather than serving the stale projection
 
 #### Scenario: Existing catalogue interaction is preserved
+
 - **WHEN** a visitor filters, sorts, pages, resets, changes result view, or hands a result to Dual Mode
 - **THEN** the resulting records, canonical URL state, fragment target, and progressive-enhancement behaviour remain consistent with the existing catalogue requirements

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -5,7 +5,7 @@
 ## 2. Results-only artwork search
 
 - [x] 2.1 Extract one canonical artwork-results workflow and make the full search view compose it; verify focused workflow tests prove identical filters, result ordering, totals, pagination, canonical state, and cancellation checkpoints.
-- [ ] 2.2 Route `/artworks/results` through the results-only workflow without loading facet projections, while preserving full-page and `#artwork-search` responses; verify handler spies plus focused HTTP tests assert the required reads, fragment shape, `HX-Push-Url`, and direct non-HTMX fallback behaviour.
+- [x] 2.2 Route `/artworks/results` through the results-only workflow without loading facet projections, while preserving full-page and `#artwork-search` responses; verify handler spies plus focused HTTP tests assert the required reads, fragment shape, `HX-Push-Url`, and direct non-HTMX fallback behaviour.
 - [ ] 2.3 Exercise the artwork-search HTMX contract in Chromium with `bunx playwright test playwright-tests/artwork-search.spec.ts playwright-tests/artwork-search-task71.spec.ts` against a running application and verify filtering, paging, URL updates, target swaps, and no-JavaScript submission remain functional.
 
 ## 3. Reusable artist availability

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -1,0 +1,36 @@
+## 1. Shared cache concurrency
+
+- [x] 1.1 Make the application cache loader coalesce concurrent misses per key while preserving generation-safe invalidation and uncached failures; verify with focused success, error, unrelated-key, and invalidation-race tests under `go test -race ./internal/utils`.
+
+## 2. Results-only artwork search
+
+- [ ] 2.1 Extract one canonical artwork-results workflow and make the full search view compose it; verify focused workflow tests prove identical filters, result ordering, totals, pagination, canonical state, and cancellation checkpoints.
+- [ ] 2.2 Route `/artworks/results` through the results-only workflow without loading facet projections, while preserving full-page and `#artwork-search` responses; verify handler spies plus focused HTTP tests assert the required reads, fragment shape, `HX-Push-Url`, and direct non-HTMX fallback behaviour.
+- [ ] 2.3 Exercise the artwork-search HTMX contract in Chromium with `bunx playwright test playwright-tests/artwork-search.spec.ts playwright-tests/artwork-search-task71.spec.ts` against a running application and verify filtering, paging, URL updates, target swaps, and no-JavaScript submission remain functional.
+
+## 3. Reusable artist availability
+
+- [ ] 3.1 Replace per-page artwork relation expansion with a compact application-scoped set of every artist ID referenced by published works, and verify repository tests cover empty data, unpublished works, duplicate relations, and artists appearing only as co-authors.
+- [ ] 3.2 Invalidate the artist-availability projection after relevant artwork saves and deletes using thin lifecycle hooks, and verify focused tests include mutation and invalidation-during-load cases without allowing an obsolete load to repopulate the cache.
+- [ ] 3.3 Use the reusable availability projection from the public artist index and both Dual Mode panes, and verify existing repository and Dual Mode tests plus a query-count assertion prove repeated page requests do not repeat the catalogue-wide relation query.
+
+## 4. Reusable collection holdings
+
+- [ ] 4.1 Load collection holdings as one compact, complete counted projection and apply name filtering, deterministic ordering, the forty-option bound, selected-value retention, and omitted totals in memory; verify focused tests reproduce all existing venue-facet outputs for empty, searched, selected, truncated, and unknown selections.
+- [ ] 4.2 Invalidate collection holdings after relevant artwork, location, and artist lifecycle changes, and verify save/delete plus concurrent invalidation tests prove the next request observes current persisted labels, eligibility, and counts.
+- [ ] 4.3 Verify concurrent cold artwork searches share one collection projection load and subsequent venue queries reuse it without unbounded query-key growth by running focused handler and cache concurrency tests under the race detector.
+
+## 5. Artist query indexes
+
+- [ ] 5.1 Capture `EXPLAIN QUERY PLAN` evidence for the supported published-artist name and birth ordering paths, select only indexes that remove demonstrated scans or temporary sorts, and record the exercised query shapes and database-size delta in the task completion evidence.
+- [ ] 5.2 Add the selected artist indexes through a timestamped reversible PocketBase migration and verify migration up/down tests prove exact index creation, rollback, existing-data preservation, and idempotent migration execution.
+- [ ] 5.3 Run focused artist repository tests for ascending name, descending name, birth order, paging, letter, school, period, and born-range filters, and confirm post-migration query plans use the intended indexes without changing returned IDs or order.
+
+## 6. Artwork list/count experiment
+
+- [ ] 6.1 Compare the existing separate artwork list/count queries with a combined window-count candidate for unfiltered, text, exact-artist including co-authors, venue, and date-range cases; retain the combined production query only if outputs are identical and representative CPU/allocation benchmarks improve without a material supported-case regression, otherwise leave production behaviour unchanged and report the rejection evidence.
+
+## 7. Final performance and regression verification
+
+- [ ] 7.1 Repeat the production-shaped concurrent profile matrix for `/artworks`, `/artworks/results`, and `/dual-mode`, recording dataset cardinality, request concurrency, throughput, latency, CPU samples, allocations per request, forced-GC retained heap, and dominant call paths; verify removed catalogue-wide work no longer appears per request and investigate any material regression before completion.
+- [ ] 7.2 Run formatting, `go vet ./...`, `go test ./... -cover`, and the focused Playwright artwork-search checks, then verify the final diff contains no startup-generation, Cloudflare, external-cache, admission-threshold, public-route, or unrelated runtime-tuning changes.

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -6,7 +6,7 @@
 
 - [x] 2.1 Extract one canonical artwork-results workflow and make the full search view compose it; verify focused workflow tests prove identical filters, result ordering, totals, pagination, canonical state, and cancellation checkpoints.
 - [x] 2.2 Route `/artworks/results` through the results-only workflow without loading facet projections, while preserving full-page and `#artwork-search` responses; verify handler spies plus focused HTTP tests assert the required reads, fragment shape, `HX-Push-Url`, and direct non-HTMX fallback behaviour.
-- [ ] 2.3 Exercise the artwork-search HTMX contract in Chromium with `bunx playwright test playwright-tests/artwork-search.spec.ts playwright-tests/artwork-search-task71.spec.ts` against a running application and verify filtering, paging, URL updates, target swaps, and no-JavaScript submission remain functional.
+- [x] 2.3 Exercise the artwork-search HTMX contract in Chromium with `bunx playwright test playwright-tests/artwork-search.spec.ts playwright-tests/artwork-search-task71.spec.ts` against a running application and verify filtering, paging, URL updates, target swaps, and no-JavaScript submission remain functional.
 
 ## 3. Reusable artist availability
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -23,7 +23,7 @@
 ## 5. Artist query indexes
 
 - [x] 5.1 Capture `EXPLAIN QUERY PLAN` evidence for the supported published-artist name and birth ordering paths, select only indexes that remove demonstrated scans or temporary sorts, and record the exercised query shapes and database-size delta in the task completion evidence.
-- [ ] 5.2 Add the selected artist indexes through a timestamped reversible PocketBase migration and verify migration up/down tests prove exact index creation, rollback, existing-data preservation, and idempotent migration execution.
+- [x] 5.2 Add the selected artist indexes through a timestamped reversible PocketBase migration and verify migration up/down tests prove exact index creation, rollback, existing-data preservation, and idempotent migration execution.
 - [ ] 5.3 Run focused artist repository tests for ascending name, descending name, birth order, paging, letter, school, period, and born-range filters, and confirm post-migration query plans use the intended indexes without changing returned IDs or order.
 
 ## 6. Artwork list/count experiment

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -22,7 +22,7 @@
 
 ## 5. Artist query indexes
 
-- [ ] 5.1 Capture `EXPLAIN QUERY PLAN` evidence for the supported published-artist name and birth ordering paths, select only indexes that remove demonstrated scans or temporary sorts, and record the exercised query shapes and database-size delta in the task completion evidence.
+- [x] 5.1 Capture `EXPLAIN QUERY PLAN` evidence for the supported published-artist name and birth ordering paths, select only indexes that remove demonstrated scans or temporary sorts, and record the exercised query shapes and database-size delta in the task completion evidence.
 - [ ] 5.2 Add the selected artist indexes through a timestamped reversible PocketBase migration and verify migration up/down tests prove exact index creation, rollback, existing-data preservation, and idempotent migration execution.
 - [ ] 5.3 Run focused artist repository tests for ascending name, descending name, birth order, paging, letter, school, period, and born-range filters, and confirm post-migration query plans use the intended indexes without changing returned IDs or order.
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -4,7 +4,7 @@
 
 ## 2. Results-only artwork search
 
-- [ ] 2.1 Extract one canonical artwork-results workflow and make the full search view compose it; verify focused workflow tests prove identical filters, result ordering, totals, pagination, canonical state, and cancellation checkpoints.
+- [x] 2.1 Extract one canonical artwork-results workflow and make the full search view compose it; verify focused workflow tests prove identical filters, result ordering, totals, pagination, canonical state, and cancellation checkpoints.
 - [ ] 2.2 Route `/artworks/results` through the results-only workflow without loading facet projections, while preserving full-page and `#artwork-search` responses; verify handler spies plus focused HTTP tests assert the required reads, fragment shape, `HX-Push-Url`, and direct non-HTMX fallback behaviour.
 - [ ] 2.3 Exercise the artwork-search HTMX contract in Chromium with `bunx playwright test playwright-tests/artwork-search.spec.ts playwright-tests/artwork-search-task71.spec.ts` against a running application and verify filtering, paging, URL updates, target swaps, and no-JavaScript submission remain functional.
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -16,7 +16,7 @@
 
 ## 4. Reusable collection holdings
 
-- [ ] 4.1 Load collection holdings as one compact, complete counted projection and apply name filtering, deterministic ordering, the forty-option bound, selected-value retention, and omitted totals in memory; verify focused tests reproduce all existing venue-facet outputs for empty, searched, selected, truncated, and unknown selections.
+- [x] 4.1 Load collection holdings as one compact, complete counted projection and apply name filtering, deterministic ordering, the forty-option bound, selected-value retention, and omitted totals in memory; verify focused tests reproduce all existing venue-facet outputs for empty, searched, selected, truncated, and unknown selections.
 - [ ] 4.2 Invalidate collection holdings after relevant artwork, location, and artist lifecycle changes, and verify save/delete plus concurrent invalidation tests prove the next request observes current persisted labels, eligibility, and counts.
 - [ ] 4.3 Verify concurrent cold artwork searches share one collection projection load and subsequent venue queries reuse it without unbounded query-key growth by running focused handler and cache concurrency tests under the race detector.
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -10,7 +10,7 @@
 
 ## 3. Reusable artist availability
 
-- [ ] 3.1 Replace per-page artwork relation expansion with a compact application-scoped set of every artist ID referenced by published works, and verify repository tests cover empty data, unpublished works, duplicate relations, and artists appearing only as co-authors.
+- [x] 3.1 Replace per-page artwork relation expansion with a compact application-scoped set of every artist ID referenced by published works, and verify repository tests cover empty data, unpublished works, duplicate relations, and artists appearing only as co-authors.
 - [ ] 3.2 Invalidate the artist-availability projection after relevant artwork saves and deletes using thin lifecycle hooks, and verify focused tests include mutation and invalidation-during-load cases without allowing an obsolete load to repopulate the cache.
 - [ ] 3.3 Use the reusable availability projection from the public artist index and both Dual Mode panes, and verify existing repository and Dual Mode tests plus a query-count assertion prove repeated page requests do not repeat the catalogue-wide relation query.
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -11,7 +11,7 @@
 ## 3. Reusable artist availability
 
 - [x] 3.1 Replace per-page artwork relation expansion with a compact application-scoped set of every artist ID referenced by published works, and verify repository tests cover empty data, unpublished works, duplicate relations, and artists appearing only as co-authors.
-- [ ] 3.2 Invalidate the artist-availability projection after relevant artwork saves and deletes using thin lifecycle hooks, and verify focused tests include mutation and invalidation-during-load cases without allowing an obsolete load to repopulate the cache.
+- [x] 3.2 Invalidate the artist-availability projection after relevant artwork saves and deletes using thin lifecycle hooks, and verify focused tests include mutation and invalidation-during-load cases without allowing an obsolete load to repopulate the cache.
 - [ ] 3.3 Use the reusable availability projection from the public artist index and both Dual Mode panes, and verify existing repository and Dual Mode tests plus a query-count assertion prove repeated page requests do not repeat the catalogue-wide relation query.
 
 ## 4. Reusable collection holdings

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -12,7 +12,7 @@
 
 - [x] 3.1 Replace per-page artwork relation expansion with a compact application-scoped set of every artist ID referenced by published works, and verify repository tests cover empty data, unpublished works, duplicate relations, and artists appearing only as co-authors.
 - [x] 3.2 Invalidate the artist-availability projection after relevant artwork saves and deletes using thin lifecycle hooks, and verify focused tests include mutation and invalidation-during-load cases without allowing an obsolete load to repopulate the cache.
-- [ ] 3.3 Use the reusable availability projection from the public artist index and both Dual Mode panes, and verify existing repository and Dual Mode tests plus a query-count assertion prove repeated page requests do not repeat the catalogue-wide relation query.
+- [x] 3.3 Use the reusable availability projection from the public artist index and both Dual Mode panes, and verify existing repository and Dual Mode tests plus a query-count assertion prove repeated page requests do not repeat the catalogue-wide relation query.
 
 ## 4. Reusable collection holdings
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -24,7 +24,7 @@
 
 - [x] 5.1 Capture `EXPLAIN QUERY PLAN` evidence for the supported published-artist name and birth ordering paths, select only indexes that remove demonstrated scans or temporary sorts, and record the exercised query shapes and database-size delta in the task completion evidence.
 - [x] 5.2 Add the selected artist indexes through a timestamped reversible PocketBase migration and verify migration up/down tests prove exact index creation, rollback, existing-data preservation, and idempotent migration execution.
-- [ ] 5.3 Run focused artist repository tests for ascending name, descending name, birth order, paging, letter, school, period, and born-range filters, and confirm post-migration query plans use the intended indexes without changing returned IDs or order.
+- [x] 5.3 Run focused artist repository tests for ascending name, descending name, birth order, paging, letter, school, period, and born-range filters, and confirm post-migration query plans use the intended indexes without changing returned IDs or order.
 
 ## 6. Artwork list/count experiment
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -18,7 +18,7 @@
 
 - [x] 4.1 Load collection holdings as one compact, complete counted projection and apply name filtering, deterministic ordering, the forty-option bound, selected-value retention, and omitted totals in memory; verify focused tests reproduce all existing venue-facet outputs for empty, searched, selected, truncated, and unknown selections.
 - [x] 4.2 Invalidate collection holdings after relevant artwork, location, and artist lifecycle changes, and verify save/delete plus concurrent invalidation tests prove the next request observes current persisted labels, eligibility, and counts.
-- [ ] 4.3 Verify concurrent cold artwork searches share one collection projection load and subsequent venue queries reuse it without unbounded query-key growth by running focused handler and cache concurrency tests under the race detector.
+- [x] 4.3 Verify concurrent cold artwork searches share one collection projection load and subsequent venue queries reuse it without unbounded query-key growth by running focused handler and cache concurrency tests under the race detector.
 
 ## 5. Artist query indexes
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -17,7 +17,7 @@
 ## 4. Reusable collection holdings
 
 - [x] 4.1 Load collection holdings as one compact, complete counted projection and apply name filtering, deterministic ordering, the forty-option bound, selected-value retention, and omitted totals in memory; verify focused tests reproduce all existing venue-facet outputs for empty, searched, selected, truncated, and unknown selections.
-- [ ] 4.2 Invalidate collection holdings after relevant artwork, location, and artist lifecycle changes, and verify save/delete plus concurrent invalidation tests prove the next request observes current persisted labels, eligibility, and counts.
+- [x] 4.2 Invalidate collection holdings after relevant artwork, location, and artist lifecycle changes, and verify save/delete plus concurrent invalidation tests prove the next request observes current persisted labels, eligibility, and counts.
 - [ ] 4.3 Verify concurrent cold artwork searches share one collection projection load and subsequent venue queries reuse it without unbounded query-key growth by running focused handler and cache concurrency tests under the race detector.
 
 ## 5. Artist query indexes

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -33,4 +33,4 @@
 ## 7. Final performance and regression verification
 
 - [x] 7.1 Repeat the production-shaped concurrent profile matrix for `/artworks`, `/artworks/results`, and `/dual-mode`, recording dataset cardinality, request concurrency, throughput, latency, CPU samples, allocations per request, forced-GC retained heap, and dominant call paths; verify removed catalogue-wide work no longer appears per request and investigate any material regression before completion.
-- [ ] 7.2 Run formatting, `go vet ./...`, `go test ./... -cover`, and the focused Playwright artwork-search checks, then verify the final diff contains no startup-generation, Cloudflare, external-cache, admission-threshold, public-route, or unrelated runtime-tuning changes.
+- [x] 7.2 Run formatting, `go vet ./...`, `go test ./... -cover`, and the focused Playwright artwork-search checks, then verify the final diff contains no startup-generation, Cloudflare, external-cache, admission-threshold, public-route, or unrelated runtime-tuning changes.

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -28,7 +28,7 @@
 
 ## 6. Artwork list/count experiment
 
-- [ ] 6.1 Compare the existing separate artwork list/count queries with a combined window-count candidate for unfiltered, text, exact-artist including co-authors, venue, and date-range cases; retain the combined production query only if outputs are identical and representative CPU/allocation benchmarks improve without a material supported-case regression, otherwise leave production behaviour unchanged and report the rejection evidence.
+- [x] 6.1 Compare the existing separate artwork list/count queries with a combined window-count candidate for unfiltered, text, exact-artist including co-authors, venue, and date-range cases; retain the combined production query only if outputs are identical and representative CPU/allocation benchmarks improve without a material supported-case regression, otherwise leave production behaviour unchanged and report the rejection evidence.
 
 ## 7. Final performance and regression verification
 

--- a/openspec/changes/improve-public-catalogue-performance/tasks.md
+++ b/openspec/changes/improve-public-catalogue-performance/tasks.md
@@ -32,5 +32,5 @@
 
 ## 7. Final performance and regression verification
 
-- [ ] 7.1 Repeat the production-shaped concurrent profile matrix for `/artworks`, `/artworks/results`, and `/dual-mode`, recording dataset cardinality, request concurrency, throughput, latency, CPU samples, allocations per request, forced-GC retained heap, and dominant call paths; verify removed catalogue-wide work no longer appears per request and investigate any material regression before completion.
+- [x] 7.1 Repeat the production-shaped concurrent profile matrix for `/artworks`, `/artworks/results`, and `/dual-mode`, recording dataset cardinality, request concurrency, throughput, latency, CPU samples, allocations per request, forced-GC retained heap, and dominant call paths; verify removed catalogue-wide work no longer appears per request and investigate any material regression before completion.
 - [ ] 7.2 Run formatting, `go vet ./...`, `go test ./... -cover`, and the focused Playwright artwork-search checks, then verify the final diff contains no startup-generation, Cloudflare, external-cache, admission-threshold, public-route, or unrelated runtime-tuning changes.


### PR DESCRIPTION
## Summary

- add the OpenSpec change for reducing request-time catalogue work
- coalesce concurrent application-cache misses per key
- extract one canonical artwork-results workflow
- route HTMX results fragments through results-only data loading, skipping unused facet projections
- preserve full-page and complete search-block responses, canonical URL state, pagination, and cancellation handling

## Verification

- `go test -race -count=10 ./internal/utils`
- `go test -race ./internal/hooks ./internal/handlers/guestbook ./internal/utils/glossary`
- `go test -race ./internal/handlers/artworks`
- `go vet ./internal/utils ./internal/handlers/artworks`
- `openspec validate improve-public-catalogue-performance --strict`

## Progress

- OpenSpec tasks: 3/16 complete
- Draft PR will be updated as the remaining atomic tasks are implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Public catalogue searches load results more efficiently, improving response times and reducing duplicate work during concurrent requests.
  * Artist and venue filter options are reused across requests while staying current after catalogue changes.

* **Search Experience**
  * Results-only interactions provide focused result fragments without unnecessary filter data.
  * Filtering, sorting, pagination, canonical URLs, and progressive-enhancement behavior remain consistent.

* **Reliability**
  * Results and filter counts stay accurate after catalogue updates.
  * Cancellation and out-of-range page handling now provide more predictable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->