### PR TITLE
fix(artworks): preserve artist scope during refinement

### DIFF
--- a/internal/assets/templ/pages/artworks.templ
+++ b/internal/assets/templ/pages/artworks.templ
@@ -47,21 +47,22 @@ type ArtworkSearchResultsView struct {
 
 // ArtworkSearchView is the page-owned contract for the artwork catalogue.
 type ArtworkSearchView struct {
-	NameField       dto.Field
-	TechniqueField  dto.Field
-	ArtistID        string
-	SchoolGroup     dto.ChipGroup
-	FormGroup       dto.ChipGroup
-	TypeGroup       dto.ChipGroup
-	PeriodGroup     dto.ChipGroup
-	LocationGroup   dto.ChipGroup
-	Facets          ArtworkSearchFacets
-	Sort            string
-	Dir             string
-	ClearUrl        string
-	DualModeContext *ArtworkSearchDualMode
-	HxTarget        string
-	Results         ArtworkSearchResultsView
+	NameField             dto.Field
+	TechniqueField        dto.Field
+	ArtistID              string
+	ArtistScopeFilingName string
+	SchoolGroup           dto.ChipGroup
+	FormGroup             dto.ChipGroup
+	TypeGroup             dto.ChipGroup
+	PeriodGroup           dto.ChipGroup
+	LocationGroup         dto.ChipGroup
+	Facets                ArtworkSearchFacets
+	Sort                  string
+	Dir                   string
+	ClearUrl              string
+	DualModeContext       *ArtworkSearchDualMode
+	HxTarget              string
+	Results               ArtworkSearchResultsView
 }
 
 // ArtworkSearchPage is the template for the artwork catalogue page.
@@ -122,6 +123,12 @@ templ ArtworkSeachFilterBlock(b ArtworkSearchView) {
 			<input type="hidden" name="dual_left_render_to" value={ b.DualModeContext.LeftRenderTo }/>
 			<input type="hidden" name="dual_right_render_to" value={ b.DualModeContext.RightRenderTo }/>
 			<input type="hidden" name="dual_target" value={ b.DualModeContext.Target }/>
+		}
+		if b.ArtistScopeFilingName != "" {
+			<div data-artwork-artist-scope aria-label="Active artist" class="mb-5 border-l-2 border-primary pl-3">
+				<p class="font-mono text-[10px] tracking-[1.5px] text-base-content/60">ARTIST</p>
+				<p class="mt-1 text-sm font-semibold leading-snug text-base-content">{ b.ArtistScopeFilingName }</p>
+			</div>
 		}
 		<div class="flex items-baseline justify-between border-b border-base-content pb-3">
 			<p class="font-mono text-[11px] tracking-[1.5px]">

--- a/internal/assets/templ/pages/artworks_test.go
+++ b/internal/assets/templ/pages/artworks_test.go
@@ -250,6 +250,34 @@ func TestArtworkFilterBlockRendersCatalogueFilters(t *testing.T) {
 	}
 }
 
+func TestArtworkFilterBlockPresentsExactArtistScopeSeparatelyFromQuery(t *testing.T) {
+	view := sampleArtworkSearchView()
+	view.ArtistID = "artistone000001"
+	view.ArtistScopeFilingName = "GOZZOLI, Benozzo"
+	view.NameField.Value = "Mocking"
+
+	rendered := renderArtworkFilterBlock(t, view)
+
+	if !strings.Contains(rendered, `type="hidden" name="artist_id" value="artistone000001"`) {
+		t.Error("expected exact artist ID as hidden submitted state")
+	}
+	if !strings.Contains(rendered, `data-artwork-artist-scope`) || !strings.Contains(rendered, "GOZZOLI, Benozzo") {
+		t.Error("expected visible filing-name artist scope")
+	}
+	if !strings.Contains(rendered, `id="artwork-query"`) || !strings.Contains(rendered, `value="Mocking"`) {
+		t.Error("expected the independent text refinement value")
+	}
+	if strings.Contains(rendered, "readonly") {
+		t.Error("artist scope must not make the text query read-only")
+	}
+
+	view.ArtistScopeFilingName = ""
+	unresolved := renderArtworkFilterBlock(t, view)
+	if strings.Contains(unresolved, `data-artwork-artist-scope`) {
+		t.Error("unresolved artist ID must not expose artist-scope details")
+	}
+}
+
 func TestArtworkFilterBlockRendersSemanticFacetDisclosures(t *testing.T) {
 	rendered := renderArtworkFilterBlock(t, sampleArtworkSearchView())
 

--- a/internal/handlers/artworks/main.go
+++ b/internal/handlers/artworks/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math"
@@ -250,6 +251,10 @@ func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBa
 	}
 	filters := resultsContext.filters
 	dualModeContext := resultsContext.dualModeContext
+	artistScopeFilingName, err := resolveArtworkSearchArtistScope(ctx, app, filters.ArtistID, checkpoint)
+	if err != nil {
+		return pages.ArtworkSearchView{}, "", err
+	}
 
 	if err := checkpoint(ctx, "artworks.search.forms"); err != nil {
 		return pages.ArtworkSearchView{}, "", err
@@ -309,22 +314,42 @@ func buildArtworkSearchViewContext(ctx context.Context, app *pocketbase.PocketBa
 			Value:       filters.TechniqueString,
 			Placeholder: "e.g. oil on canvas",
 		},
-		ArtistID:        filters.ArtistID,
-		SchoolGroup:     schoolGroup,
-		FormGroup:       formGroup,
-		TypeGroup:       typeGroup,
-		PeriodGroup:     periodGroup,
-		LocationGroup:   collectionGroup,
-		Facets:          buildArtworkSearchFacets(filters, schoolGroup, formGroup, typeGroup, periodGroup, venueOptions),
-		Sort:            filters.Sort,
-		Dir:             filters.SortDir,
-		ClearUrl:        buildArtworkSearchClearPath(dualModeContext),
-		DualModeContext: dualModeContext,
-		HxTarget:        "#artwork-search",
-		Results:         resultsContext.view,
+		ArtistID:              filters.ArtistID,
+		ArtistScopeFilingName: artistScopeFilingName,
+		SchoolGroup:           schoolGroup,
+		FormGroup:             formGroup,
+		TypeGroup:             typeGroup,
+		PeriodGroup:           periodGroup,
+		LocationGroup:         collectionGroup,
+		Facets:                buildArtworkSearchFacets(filters, schoolGroup, formGroup, typeGroup, periodGroup, venueOptions),
+		Sort:                  filters.Sort,
+		Dir:                   filters.SortDir,
+		ClearUrl:              buildArtworkSearchClearPath(dualModeContext),
+		DualModeContext:       dualModeContext,
+		HxTarget:              "#artwork-search",
+		Results:               resultsContext.view,
 	}
 
 	return view, resultsContext.canonical, nil
+}
+
+func resolveArtworkSearchArtistScope(ctx context.Context, app *pocketbase.PocketBase, artistID string, checkpoint artworkSearchCheckpoint) (string, error) {
+	if artistID == "" {
+		return "", nil
+	}
+	if err := checkpoint(ctx, "artworks.search.artist_scope"); err != nil {
+		return "", err
+	}
+
+	artist, err := repositories.NewArtistRecordRepository(app).FindPublishedArtist(artistID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return artist.GetString("filing_name"), nil
 }
 
 func buildArtworkSearchResults(app *pocketbase.PocketBase, filters *filters, dualModeContext *pages.ArtworkSearchDualMode, records []*core.Record, recordsCount int, page int, limit int) (pages.ArtworkSearchResultsView, error) {

--- a/internal/handlers/artworks/search_integration_test.go
+++ b/internal/handlers/artworks/search_integration_test.go
@@ -110,6 +110,7 @@ func newArtworkSearchApp(t *testing.T) *pocketbase.PocketBase {
 		&core.TextField{Id: "artist_name", Name: "name", Required: true},
 		&core.TextField{Id: "artist_filing_name", Name: "filing_name"},
 		&core.TextField{Id: "artist_short_name", Name: "short_name"},
+		&core.BoolField{Id: "artist_published", Name: "published"},
 	)
 	if err := app.Save(artists); err != nil {
 		t.Fatalf("save artists: %v", err)
@@ -260,6 +261,7 @@ func saveSearchArtist(t *testing.T, app *pocketbase.PocketBase, id string, name 
 	record.Set("name", name)
 	record.Set("filing_name", name)
 	record.Set("short_name", name)
+	record.Set("published", true)
 	if err := app.Save(record); err != nil {
 		t.Fatalf("save artist %s: %v", id, err)
 	}
@@ -350,6 +352,12 @@ func TestBuildArtworkSearchViewFiltersByExactArtistID(t *testing.T) {
 	if view.ArtistID != "artistone000001" {
 		t.Errorf("view artist ID = %q, want artistone000001", view.ArtistID)
 	}
+	if view.ArtistScopeFilingName != "Aachen, Hans von" {
+		t.Errorf("artist scope = %q, want Aachen, Hans von", view.ArtistScopeFilingName)
+	}
+	if view.ClearUrl != "/artworks" {
+		t.Errorf("clear URL = %q, want /artworks without artist scope", view.ClearUrl)
+	}
 	if view.Results.ListUrl != "/artworks?artist_id=artistone000001&view=list" {
 		t.Errorf("list URL = %q", view.Results.ListUrl)
 	}
@@ -378,6 +386,37 @@ func TestBuildArtworkSearchViewFiltersByExactArtistID(t *testing.T) {
 	}
 	if unknown.Results.ResultCount != 0 || len(unknown.Results.Artworks) != 0 {
 		t.Fatalf("unknown artist results = %d, want 0", unknown.Results.ResultCount)
+	}
+	if unknown.ArtistScopeFilingName != "" {
+		t.Errorf("unknown artist scope = %q, want empty", unknown.ArtistScopeFilingName)
+	}
+
+	saveSearchArtist(t, app, "unpublish000001", "Artist, Unpublished")
+	unpublishedArtist, err := app.FindRecordById("artists", "unpublish000001")
+	if err != nil {
+		t.Fatalf("find unpublished artist fixture: %v", err)
+	}
+	unpublishedArtist.Set("published", false)
+	if err := app.Save(unpublishedArtist); err != nil {
+		t.Fatalf("save unpublished artist fixture: %v", err)
+	}
+	unpublished, _, err := buildArtworkSearchView(app, neturl.Values{"artist_id": {"unpublish000001"}}, 1, 16)
+	if err != nil {
+		t.Fatalf("build unpublished artist view: %v", err)
+	}
+	if unpublished.ArtistScopeFilingName != "" {
+		t.Errorf("unpublished artist scope = %q, want empty", unpublished.ArtistScopeFilingName)
+	}
+
+	empty, _, err := buildArtworkSearchView(app, neturl.Values{
+		"artist_id": {"artistone000001"},
+		"q":         {"No such work"},
+	}, 1, 16)
+	if err != nil {
+		t.Fatalf("build empty refined artist view: %v", err)
+	}
+	if empty.Results.ResultCount != 0 || empty.ArtistScopeFilingName != "Aachen, Hans von" {
+		t.Errorf("empty refined artist view = count %d, scope %q", empty.Results.ResultCount, empty.ArtistScopeFilingName)
 	}
 }
 
@@ -1025,6 +1064,9 @@ func TestArtworksRouteRendersFullPageAndFragment(t *testing.T) {
 		if !strings.Contains(body, `type="hidden" name="artist_id" value="artistone000001"`) {
 			t.Error("full page must retain exact artist ID as non-visible GET state")
 		}
+		if !strings.Contains(body, `data-artwork-artist-scope`) || !strings.Contains(body, "Artist One") {
+			t.Error("full page must present the resolved artist scope")
+		}
 
 		fragment := httptest.NewRecorder()
 		fragmentRequest := httptest.NewRequest(http.MethodGet, "/artworks/results?artist_id=artistone000001&q=Only&sort=date", nil)
@@ -1042,6 +1084,9 @@ func TestArtworksRouteRendersFullPageAndFragment(t *testing.T) {
 		}
 		if strings.Contains(fragmentBody, "id=\"artwork-filters\"") {
 			t.Error("fragment must not include the filter form")
+		}
+		if strings.Contains(fragmentBody, `data-artwork-artist-scope`) {
+			t.Error("results-only fragment must not include artist-scope presentation")
 		}
 		if !strings.Contains(fragmentBody, "Only Work") {
 			t.Error("fragment must retain the artist holding while refining the catalogue query")

--- a/openspec/changes/preserve-artwork-artist-scope/.openspec.yaml
+++ b/openspec/changes/preserve-artwork-artist-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/preserve-artwork-artist-scope/design.md
+++ b/openspec/changes/preserve-artwork-artist-scope/design.md
@@ -1,0 +1,52 @@
+## Context
+
+See proposal.md for motivation and the catalogue-exploration delta for observable behaviour. Exact artist scope is already represented by `artist_id` in filter state, canonical URL builders, and a hidden GET form control. The current Go integration coverage constructs refinement URLs directly, so it proves server handling but not the browser's form-to-HTMX parameter contract. The page-owned artwork-search view carries only the identifier and therefore cannot present the artist's name.
+
+Artwork-search form interactions replace the complete `#artwork-search` block, while pagination can request only the results fragment. The results-only path deliberately avoids loading filter and page projections, so artist-scope presentation must not add work to that response.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat the hidden `artist_id`, HTMX form submission, handler parsing, canonical URL, replacement block, and resulting DOM as one verified interaction contract.
+- Resolve a public artist scope independently from the current result page so its name remains visible when additional filters yield no works.
+- Preserve the results-only response's bounded data-work contract.
+
+**Non-Goals:**
+
+- Do not change the meaning or public shape of `artist_id`, `artist`, or `q`.
+- Do not make the scope independently removable; the existing reset action remains the way to clear it and all other filters.
+- Do not reveal unpublished artist details or infer a name from matching artwork records.
+
+## Decisions
+
+### Present exact artist scope separately from the query
+
+The page-owned search view will carry an optional resolved artist-scope presentation using the public artist's established filing-name identity. The filter rail will render that scope separately from the editable title-or-artist query. `artist_id` remains the submitted and canonical value; the displayed name is presentation only.
+
+Alternative considered: put the artist name into the read-only `q` field and let `artist_id` supersede it. Rejected because it makes a displayed query value semantically false, prevents further text refinement, and couples exact relationship state to free-text search.
+
+### Resolve only published artist identity on complete search views
+
+When `artist_id` is active, complete page and search-block construction will use the existing public artist lookup boundary to resolve the filing name. A missing or unpublished artist will leave the optional presentation empty while the exact identifier continues through normal filtering and canonicalisation, preserving the honest no-results behaviour.
+
+Results-only fragment construction will not perform this lookup because it neither renders nor swaps the filter rail. This preserves the catalogue requirement that results-only requests avoid page-wide projection work.
+
+Alternative considered: derive the name from the returned artwork page. Rejected because a refined or out-of-range result page can be empty and a co-authored result's primary displayed artist need not be the scoped artist.
+
+### Prove preservation at the browser boundary
+
+A Playwright scenario will enter the search from an artist record, assert the hidden identifier and visible filing-name scope, refine through the live form, and assert that the outgoing/resulting URL and replaced DOM retain the exact scope. Focused Go tests will continue to cover view construction and template output, but will not substitute for the browser assertion.
+
+The implementation should first reproduce the reported interaction with this scenario. Any preservation correction will remain at the form/HTMX contract boundary established by that evidence rather than introducing client-side URL reconstruction.
+
+## Risks / Trade-offs
+
+- [The existing source already appears to serialise `artist_id`, so the reported failure may depend on browser interaction or deployed assets] -> Establish the failure with Playwright and change only the demonstrated contract break; retain the regression even if the code correction is minimal.
+- [Artist identity lookup adds work to artwork search] -> Perform it only when `artist_id` is present and only for responses that render the complete search block.
+- [An arbitrary identifier could expose unpublished artist data] -> Use the existing published-artist lookup contract and render no artist details when it does not resolve.
+- [The visible label could be mistaken for editable text] -> Present it as scope metadata outside the query control and keep `q` visibly editable.
+
+## Migration Plan
+
+No data or URL migration is required. Deploy the server and generated frontend assets together. Rollback removes the scope presentation and regression-specific correction while existing `artist_id` URLs retain their established server semantics.

--- a/openspec/changes/preserve-artwork-artist-scope/proposal.md
+++ b/openspec/changes/preserve-artwork-artist-scope/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Artwork search opened from an artist record is intended to remain constrained by that exact artist while visitors refine the catalogue, but the observed browser interaction can lose that scope and the page gives no visible indication that an exact artist filter is active. The interaction needs browser-level assurance and a clear artist-scope presentation without repurposing the free-text query.
+
+## What Changes
+
+- Preserve the exact `artist_id` constraint through browser-driven artwork-search refinements and the resulting canonical URL.
+- Show the resolved public artist name as a distinct active scope on artwork search while keeping the title-or-artist query available for additional text refinement.
+- Keep the exact artist identifier as non-visible request state; do not expose an editable artist-ID control or place the artist name in the query value.
+- Retain the existing reset, unknown-identifier, legacy artist URL, sorting, paging, result-view, and Dual Mode semantics.
+- Add browser coverage that enters artwork search from an artist record and proves both the visible scope and its preservation after refinement.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `catalogue-exploration`: Make the active exact-artist scope visible and require browser-driven refinements to retain that scope while leaving free-text refinement independent.
+
+## Impact
+
+- Artwork-search view construction and Templ presentation.
+- Exact artist lookup through the existing public artist catalogue boundary.
+- Artwork-search handler/template tests and Playwright coverage.
+- No route, database schema, dependency, or public parameter changes.

--- a/openspec/changes/preserve-artwork-artist-scope/specs/catalogue-exploration/spec.md
+++ b/openspec/changes/preserve-artwork-artist-scope/specs/catalogue-exploration/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Live catalogue filtering
+
+The system SHALL let visitors filter artworks by text, school, form, type, reference-defined date range controls, and an exact artist-record identifier in URL state, and SHALL render a result summary, matching works, and an empty state. The exact artist-record filter SHALL select published artworks that include the identified artist, including co-authored works, without adding an artist identifier control to the visible catalogue form. While a valid exact artist-record filter is active, the system SHALL visibly identify the resolved public artist independently from the editable text query.
+
+#### Scenario: Visitor applies a text filter
+
+- **WHEN** a visitor enters a catalogue query and submits or waits for the enhanced search trigger
+- **THEN** the result block shows only matching works and the browser URL represents the active filter state.
+
+#### Scenario: Visitor opens an artist holding
+
+- **WHEN** a visitor follows `FIND MORE BY … IN THE ARTWORK SEARCH` from a public artist record
+- **THEN** the artwork-search URL contains that artist's exact public record identifier, the page visibly identifies that artist as the active scope, and results contain published works related to that record only.
+
+#### Scenario: Visitor refines an artist holding
+
+- **WHEN** a visitor with an exact artist-record filter changes the editable text query, another catalogue filter, result view, sort order, page, or Dual Mode hand-off
+- **THEN** the exact artist-record filter remains in the resulting URL, continues to constrain the results, and remains visibly identified independently from the text query.
+
+#### Scenario: Visitor resets filters
+
+- **WHEN** a visitor activates the reset control while an exact artist-record filter is active
+- **THEN** the identifier, visible artist scope, and all other active filters clear and the unfiltered catalogue state is shown.
+
+#### Scenario: Unknown artist identifier
+
+- **WHEN** a visitor opens artwork search with an artist identifier that relates to no published artworks
+- **THEN** the system renders the existing honest no-matching-works state without substituting a name-based search.
+
+#### Scenario: Artist identifier does not resolve publicly
+
+- **WHEN** an exact artist-record identifier does not identify a published artist
+- **THEN** the system does not display artist details for that identifier.
+
+#### Scenario: Legacy artist URL remains usable
+
+- **WHEN** a visitor opens an existing name-based artist search URL
+- **THEN** the system preserves its existing name-based search behaviour without presenting it as an exact artist scope.
+
+#### Scenario: Exact artist identifier takes precedence
+
+- **WHEN** a visitor opens artwork search with both a name-based artist filter and an exact artist-record identifier
+- **THEN** the system uses the exact identifier, omits the name-based value from the canonical URL, displays the resolved exact artist scope, and renders only the exact artist's published works.
+
+#### Scenario: JavaScript is disabled
+
+- **WHEN** a visitor submits active catalogue filters without JavaScript, including an exact artist-record filter opened from an artist record
+- **THEN** the server renders the matching result page at a shareable URL with the identifier and visible artist scope retained.

--- a/openspec/changes/preserve-artwork-artist-scope/tasks.md
+++ b/openspec/changes/preserve-artwork-artist-scope/tasks.md
@@ -1,0 +1,3 @@
+## 1. Exact artist search interaction
+
+- [x] 1.1 Reproduce the artist-record-to-artwork-search refinement in Playwright; correct the demonstrated form/HTMX contract so the hidden `artist_id`, canonical URL, exact result constraint, and replacement DOM retain the scope; resolve the published artist's filing name only for complete search views and render it as scope metadata separate from the editable `q` field, with no details for an unresolved or unpublished ID; add focused view/template coverage for resolved, empty-result, unresolved, reset, and results-only cases; then run `templ generate`, the affected Go tests, and the focused Playwright artwork-search scenario successfully.

--- a/playwright-tests/record-production.spec.ts
+++ b/playwright-tests/record-production.spec.ts
@@ -60,3 +60,53 @@ test.describe("production records without JavaScript", () => {
 		).toBeVisible();
 	});
 });
+
+test("artist record scope remains visible through live artwork refinement", async ({
+	page,
+}) => {
+	const artistID = "r9fb82d431d2a5c";
+	await page.goto(artistPath);
+	await page
+		.getByRole("link", {
+			name: /FIND MORE BY Benozzo Gozzoli IN THE ARTWORK SEARCH/,
+		})
+		.click();
+
+	const form = page.locator("#artwork-filters");
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === "/artworks" &&
+			url.searchParams.get("artist_id") === artistID,
+	);
+	await expect(form.locator("input[name='artist_id']")).toHaveValue(artistID);
+	await expect(form.locator("[data-artwork-artist-scope]")).toContainText(
+		"GOZZOLI, Benozzo",
+	);
+
+	const query = form.locator("#artwork-query");
+	await expect(query).toBeEditable();
+	const refinement = page.waitForResponse((response) => {
+		const url = new URL(response.url());
+		return (
+			url.pathname === "/artworks" &&
+			url.searchParams.get("artist_id") === artistID &&
+			url.searchParams.get("q") === "Mocking"
+		);
+	});
+	await query.fill("Mocking");
+	await refinement;
+
+	await expect(page).toHaveURL(
+		(url) =>
+			url.pathname === "/artworks" &&
+			url.searchParams.get("artist_id") === artistID &&
+			url.searchParams.get("q") === "Mocking",
+	);
+	await expect(form.locator("input[name='artist_id']")).toHaveValue(artistID);
+	await expect(form.locator("[data-artwork-artist-scope]")).toContainText(
+		"GOZZOLI, Benozzo",
+	);
+	await expect(page.locator("#artwork-search-results")).toContainText(
+		"The Mocking of Christ",
+	);
+});


### PR DESCRIPTION
## Summary
- preserve exact artist scope when refining artwork search through HTMX
- display the published artist filing name separately from the editable text query
- cover resolved, unresolved, unpublished, empty-result, reset, fragment, and browser interactions

## Verification
- `go test ./internal/assets/templ/pages ./internal/handlers/artworks`
- `bunx biome check playwright-tests/record-production.spec.ts`
- `bunx playwright test playwright-tests/record-production.spec.ts --grep "artist record scope remains visible through live artwork refinement" --project=chromium`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artwork searches opened from an artist record now retain the exact artist filter while users refine queries, submit forms, sort, or paginate.
  * The active artist appears as a distinct scope label, while the text search remains editable independently.
  * Artist filtering is preserved in the URL and across dynamic result updates.

* **Bug Fixes**
  * Improved handling of unknown or unpublished artist identifiers so unresolved artist details are not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->